### PR TITLE
feat(forum): add post dislike and pin functionality

### DIFF
--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -237,6 +237,40 @@ npm run db:seed
 
 注意：此操作会清空当前数据库全部业务表。
 
+### 6.3 帖子功能升级说明（v2.5+）
+
+本次发布新增帖子点赞、踩、置顶功能，数据库升级步骤：
+
+**已包含在 `db:deploy` 中，无需手动操作。**
+
+相关数据库变更：
+
+| 表名 | 变更类型 | 说明 |
+|------|---------|------|
+| `Post` | 新增列 | `dislikesCount` Int，默认 0 |
+| `Post` | 新增列 | `isPinned` Boolean，默认 false |
+| `PostDislike` | 新建表 | 踩记录表，防止重复踩 |
+
+**PostDislike 表结构：**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | String | 主键 |
+| postId | String | 关联帖子 ID |
+| userUid | String | 踩的用户 ID |
+| createdAt | DateTime | 踩的时间 |
+
+唯一约束：`([postId, userUid])` - 同一用户对同一帖子只能踩一次。
+
+**API 变更：**
+
+| 端点 | 方法 | 功能 | 权限 |
+|------|------|------|------|
+| `/api/posts/:id/dislike` | POST | 踩（toggle） | 登录用户 |
+| `/api/posts/:id/dislike` | DELETE | 取消踩 | 登录用户 |
+| `/api/posts/:id/pin` | POST | 置顶 | 管理员 |
+| `/api/posts/:id/pin` | DELETE | 取消置顶 | 管理员 |
+
 ---
 
 ## 7. 构建并启动服务
@@ -349,6 +383,42 @@ certbot renew --dry-run
 - 管理员账号可进入后台
 - 图集上传可写入 `uploads/`
 - 数据可写入 PostgreSQL
+
+### 11.1 帖子功能验证（v2.5+）
+
+帖子点赞、踩、置顶功能验证：
+
+```bash
+# 创建测试帖子（需先登录）
+curl -X POST http://127.0.0.1:3000/api/posts \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"title":"测试帖子","section":"general","content":"内容"}'
+
+# 点赞帖子
+curl -X POST http://127.0.0.1:3000/api/posts/<帖子ID>/like \
+  -b cookie.txt -c cookie.txt
+
+# 踩帖子
+curl -X POST http://127.0.0.1:3000/api/posts/<帖子ID>/dislike \
+  -b cookie.txt -c cookie.txt
+
+# 置顶帖子（仅管理员）
+curl -X POST http://127.0.0.1:3000/api/posts/<帖子ID>/pin \
+  -b cookie.txt -c cookie.txt
+
+# 取消置顶（仅管理员）
+curl -X DELETE http://127.0.0.1:3000/api/posts/<帖子ID>/pin \
+  -b cookie.txt -c cookie.txt
+```
+
+验证点：
+- 重复点赞/踩会自动切换状态（toggle）
+- 同一用户对同一帖子只能踩一次（`PostDislike` 表唯一约束）
+- 非管理员调用置顶 API 返回 403
+- 帖子列表默认按置顶优先排序
+
+### 11.2 图集上传链路专项验证
 
 ### 11.1 图集上传链路专项验证
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model User {
   galleries     Gallery[]      @relation("UserGalleries")
   musicAdded    MusicTrack[]   @relation("MusicAddedBy")
   postLikes     PostLike[]
+  postDislikes  PostDislike[] @relation("UserDislikes")
   favorites     Favorite[]
   moderationLogs ModerationLog[] @relation("ModerationOperator")
   userBanOps    UserBanLog[]   @relation("UserBanActionBy")
@@ -168,6 +169,8 @@ model Post {
   id            String        @id @default(cuid())
   title         String
   section       String
+  musicDocId    String?
+  albumDocId    String?
   content       String
   tags          Json?
   authorUid     String
@@ -178,15 +181,22 @@ model Post {
   hotScore      Float         @default(0)
   viewCount     Int           @default(0)
   likesCount    Int           @default(0)
+  dislikesCount Int           @default(0)
   commentsCount Int           @default(0)
+  isPinned      Boolean       @default(false)
   createdAt     DateTime      @default(now())
   updatedAt     DateTime      @updatedAt
   sectionRef    Section       @relation(fields: [section], references: [id], onDelete: Restrict)
+  musicRef      MusicTrack?   @relation(fields: [musicDocId], references: [docId], onDelete: SetNull)
+  albumRef      Album?        @relation(fields: [albumDocId], references: [docId], onDelete: SetNull)
   author        User          @relation("UserPosts", fields: [authorUid], references: [uid], onDelete: Cascade)
   comments      PostComment[]
   likes         PostLike[]
+  dislikes      PostDislike[]
 
   @@index([section])
+  @@index([musicDocId, updatedAt])
+  @@index([albumDocId, updatedAt])
   @@index([status, updatedAt])
   @@index([updatedAt])
   @@index([hotScore, updatedAt])
@@ -247,6 +257,18 @@ model PostLike {
   createdAt DateTime @default(now())
   post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
   user      User     @relation(fields: [userUid], references: [uid], onDelete: Cascade)
+
+  @@unique([postId, userUid])
+  @@index([userUid, createdAt])
+}
+
+model PostDislike {
+  id        String   @id @default(cuid())
+  postId    String
+  userUid   String
+  createdAt DateTime @default(now())
+  post      Post     @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User     @relation("UserDislikes", fields: [userUid], references: [uid], onDelete: Cascade)
 
   @@unique([postId, userUid])
   @@index([userUid, createdAt])
@@ -487,6 +509,7 @@ model Album {
   updatedAt          DateTime            @updatedAt
   covers             AlbumCover[]
   songRelations      SongAlbumRelation[]
+  posts              Post[]
 
   @@unique([platform, sourceId, resourceType])
   @@index([title])
@@ -517,6 +540,7 @@ model MusicTrack {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   adder     User?    @relation("MusicAddedBy", fields: [addedBy], references: [uid], onDelete: SetNull)
+  posts     Post[]
   covers    SongCover[]
   albumRelations SongAlbumRelation[]
   instrumentalLinks   SongInstrumentalRelation[] @relation("SongInstrumentalSource")

--- a/server.ts
+++ b/server.ts
@@ -108,6 +108,7 @@ type ModerationTargetType = 'wiki' | 'post';
 type NotificationType = 'reply' | 'like' | 'review_result';
 type BrowsingTargetType = 'wiki' | 'post' | 'music';
 type PostSortType = 'latest' | 'hot' | 'recommended';
+const MUSIC_SECTION_ID = 'music';
 
 type WikiRelationRecord = {
   type: WikiRelationType;
@@ -1800,6 +1801,14 @@ function parsePostSort(value: unknown): PostSortType {
   return 'latest';
 }
 
+function normalizeOptionalDocId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
 function normalizeKeyword(value: string) {
   return value.trim().toLowerCase().replace(/\s+/g, ' ').slice(0, 64);
 }
@@ -2419,6 +2428,8 @@ function toPostResponse(post: {
   id: string;
   title: string;
   section: string;
+  musicDocId?: string | null;
+  albumDocId?: string | null;
   content: string;
   tags: unknown;
   authorUid: string;
@@ -2429,7 +2440,9 @@ function toPostResponse(post: {
   hotScore?: number;
   viewCount?: number;
   likesCount: number;
+  dislikesCount: number;
   commentsCount: number;
+  isPinned?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }) {
@@ -2438,6 +2451,8 @@ function toPostResponse(post: {
     hotScore: post.hotScore ?? 0,
     viewCount: post.viewCount ?? 0,
     tags: serializeTags(post.tags),
+    musicDocId: post.musicDocId || null,
+    albumDocId: post.albumDocId || null,
     reviewedAt: post.reviewedAt ? post.reviewedAt.toISOString() : null,
     createdAt: post.createdAt.toISOString(),
     updatedAt: post.updatedAt.toISOString(),
@@ -3109,8 +3124,9 @@ app.get('/api/users/:uid/posts', async (req: AuthenticatedRequest, res) => {
 
     const likedPostSet = new Set<string>();
     const favoritedPostSet = new Set<string>();
+    const dislikedPostSet = new Set<string>();
     if (req.authUser && posts.length) {
-      const [likedPosts, favoritedPosts] = await Promise.all([
+      const [likedPosts, favoritedPosts, dislikedPosts] = await Promise.all([
         prisma.postLike.findMany({
           where: {
             userUid: req.authUser.uid,
@@ -3126,9 +3142,17 @@ app.get('/api/users/:uid/posts', async (req: AuthenticatedRequest, res) => {
           },
           select: { targetId: true },
         }),
+        prisma.postDislike.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            postId: { in: posts.map((item) => item.id) },
+          },
+          select: { postId: true },
+        }),
       ]);
       likedPosts.forEach((item) => likedPostSet.add(item.postId));
       favoritedPosts.forEach((item) => favoritedPostSet.add(item.targetId));
+      dislikedPosts.forEach((item) => dislikedPostSet.add(item.postId));
     }
 
     res.json({
@@ -3136,10 +3160,8 @@ app.get('/api/users/:uid/posts', async (req: AuthenticatedRequest, res) => {
         ...toPostResponse(post),
         likedByMe: likedPostSet.has(post.id),
         favoritedByMe: favoritedPostSet.has(post.id),
+        dislikedByMe: dislikedPostSet.has(post.id),
       })),
-      total,
-      page,
-      limit,
     });
   } catch (error) {
     console.error('Fetch user posts error:', error);
@@ -4960,11 +4982,11 @@ app.get('/api/posts', async (req: AuthenticatedRequest, res) => {
 
     let orderBy: Array<Record<string, 'asc' | 'desc'>>;
     if (sort === 'hot') {
-      orderBy = [{ hotScore: 'desc' }, { updatedAt: 'desc' }];
+      orderBy = [{ isPinned: 'desc' }, { hotScore: 'desc' }, { updatedAt: 'desc' }];
     } else if (sort === 'recommended') {
-      orderBy = [{ commentsCount: 'desc' }, { likesCount: 'desc' }, { updatedAt: 'desc' }];
+      orderBy = [{ isPinned: 'desc' }, { commentsCount: 'desc' }, { likesCount: 'desc' }, { updatedAt: 'desc' }];
     } else {
-      orderBy = [{ updatedAt: 'desc' }];
+      orderBy = [{ isPinned: 'desc' }, { updatedAt: 'desc' }];
     }
 
     const posts = await prisma.post.findMany({
@@ -5122,7 +5144,7 @@ app.get('/api/posts/:id', async (req: AuthenticatedRequest, res) => {
       orderBy: { createdAt: 'asc' },
     });
 
-    const [likedByMe, favoritedByMe] = req.authUser
+    const [likedByMe, favoritedByMe, dislikedByMe] = req.authUser
       ? await Promise.all([
           prisma.postLike.count({
             where: {
@@ -5137,8 +5159,14 @@ app.get('/api/posts/:id', async (req: AuthenticatedRequest, res) => {
               userUid: req.authUser.uid,
             },
           }).then((count) => count > 0),
+          prisma.postDislike.count({
+            where: {
+              postId: req.params.id,
+              userUid: req.authUser.uid,
+            },
+          }).then((count) => count > 0),
         ])
-      : [false, false];
+      : [false, false, false];
 
     res.json({
       post: {
@@ -5148,6 +5176,7 @@ app.get('/api/posts/:id', async (req: AuthenticatedRequest, res) => {
         }),
         likedByMe,
         favoritedByMe,
+        dislikedByMe,
       },
       comments: comments.map(toCommentResponse),
     });
@@ -5159,12 +5188,14 @@ app.get('/api/posts/:id', async (req: AuthenticatedRequest, res) => {
 
 app.post('/api/posts', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { title, section, content, tags, status } = req.body as {
+    const { title, section, content, tags, status, musicDocId, albumDocId } = req.body as {
       title?: string;
       section?: string;
       content?: string;
       tags?: string[];
       status?: ContentStatus;
+      musicDocId?: string;
+      albumDocId?: string;
     };
 
     if (!title || !section || !content) {
@@ -5172,13 +5203,31 @@ app.post('/api/posts', requireAuth, requireActiveUser, async (req: Authenticated
       return;
     }
 
-    const sectionExists = await prisma.section.findUnique({
-      where: { id: section },
-      select: { id: true },
-    });
-    if (!sectionExists) {
-      res.status(400).json({ error: '版块不存在' });
-      return;
+    const normalizedMusicDocId = normalizeOptionalDocId(musicDocId);
+    const normalizedAlbumDocId = normalizeOptionalDocId(albumDocId);
+
+    let finalSection = section;
+    if (normalizedMusicDocId || normalizedAlbumDocId) {
+      const musicSection = await prisma.section.findUnique({
+        where: { id: MUSIC_SECTION_ID },
+        select: { id: true },
+      });
+      if (!musicSection) {
+        res.status(500).json({ error: '音乐版块不存在，请先在后台创建' });
+        return;
+      }
+      finalSection = MUSIC_SECTION_ID;
+    }
+
+    if (finalSection !== section) {
+      const sectionExists = await prisma.section.findUnique({
+        where: { id: section },
+        select: { id: true },
+      });
+      if (!sectionExists) {
+        res.status(400).json({ error: '版块不存在' });
+        return;
+      }
     }
 
     const nextStatus = normalizePostWriteStatus(status, req.authUser!);
@@ -5186,7 +5235,7 @@ app.post('/api/posts', requireAuth, requireActiveUser, async (req: Authenticated
     const post = await prisma.post.create({
       data: {
         title,
-        section,
+        section: finalSection,
         content,
         tags: tags || [],
         status: nextStatus,
@@ -5194,6 +5243,8 @@ app.post('/api/posts', requireAuth, requireActiveUser, async (req: Authenticated
         reviewedBy: null,
         reviewedAt: null,
         authorUid: req.authUser!.uid,
+        musicDocId: normalizedMusicDocId,
+        albumDocId: normalizedAlbumDocId,
       },
     });
 
@@ -5514,18 +5565,23 @@ app.post('/api/posts/:id/submit', requireAuth, requireActiveUser, async (req: Au
 
 app.put('/api/posts/:id', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { title, section, content, tags, status } = req.body as {
+    const { title, section, content, tags, status, musicDocId, albumDocId } = req.body as {
       title?: string;
       section?: string;
       content?: string;
       tags?: string[];
       status?: ContentStatus;
+      musicDocId?: string;
+      albumDocId?: string;
     };
 
     if (!title || !section || !content) {
       res.status(400).json({ error: '缺少必要字段' });
       return;
     }
+
+    const normalizedMusicDocId = normalizeOptionalDocId(musicDocId);
+    const normalizedAlbumDocId = normalizeOptionalDocId(albumDocId);
 
     const existingPost = await prisma.post.findUnique({
       where: { id: req.params.id },
@@ -5548,13 +5604,28 @@ app.put('/api/posts/:id', requireAuth, requireActiveUser, async (req: Authentica
       return;
     }
 
-    const sectionExists = await prisma.section.findUnique({
-      where: { id: section },
-      select: { id: true },
-    });
-    if (!sectionExists) {
-      res.status(400).json({ error: '版块不存在' });
-      return;
+    let finalSection = section;
+    if (normalizedMusicDocId || normalizedAlbumDocId) {
+      const musicSection = await prisma.section.findUnique({
+        where: { id: MUSIC_SECTION_ID },
+        select: { id: true },
+      });
+      if (!musicSection) {
+        res.status(500).json({ error: '音乐版块不存在，请先在后台创建' });
+        return;
+      }
+      finalSection = MUSIC_SECTION_ID;
+    }
+
+    if (finalSection !== section) {
+      const sectionExists = await prisma.section.findUnique({
+        where: { id: section },
+        select: { id: true },
+      });
+      if (!sectionExists) {
+        res.status(400).json({ error: '版块不存在' });
+        return;
+      }
     }
 
     let nextStatus: ContentStatus;
@@ -5571,13 +5642,15 @@ app.put('/api/posts/:id', requireAuth, requireActiveUser, async (req: Authentica
       where: { id: req.params.id },
       data: {
         title,
-        section,
+        section: finalSection,
         content,
         tags: Array.isArray(tags) ? tags : [],
         status: nextStatus,
         reviewNote: null,
         reviewedBy: null,
         reviewedAt: null,
+        musicDocId: normalizedMusicDocId,
+        albumDocId: normalizedAlbumDocId,
       },
     });
 
@@ -5709,6 +5782,110 @@ app.delete('/api/posts/:id/like', requireAuth, requireActiveUser, async (req: Au
   } catch (error) {
     console.error('Unlike post error:', error);
     res.status(500).json({ error: '取消点赞失败' });
+  }
+});
+
+app.post('/api/posts/:id/dislike', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const postId = req.params.id;
+    const post = await prisma.post.findUnique({
+      where: { id: postId },
+      select: {
+        id: true,
+        status: true,
+        authorUid: true,
+      },
+    });
+
+    if (!post || !canViewPost(post, req.authUser)) {
+      res.status(404).json({ error: '帖子未找到' });
+      return;
+    }
+
+    await prisma.$transaction(async (tx) => {
+      try {
+        await tx.postDislike.create({
+          data: {
+            postId,
+            userUid: req.authUser!.uid,
+          },
+        });
+      } catch {
+        return;
+      }
+
+      await tx.post.update({
+        where: { id: postId },
+        data: {
+          dislikesCount: { increment: 1 },
+        },
+      });
+    });
+
+    const dislikesCount = await prisma.postDislike.count({ where: { postId } });
+
+    const updatedPost = await prisma.post.update({
+      where: { id: postId },
+      data: {
+        dislikesCount,
+      },
+    });
+
+    const hotScore = calculatePostHotScore(updatedPost);
+    await prisma.post.update({
+      where: { id: postId },
+      data: { hotScore },
+    });
+
+    res.json({ disliked: true, dislikesCount });
+  } catch (error) {
+    console.error('Dislike post error:', error);
+    res.status(500).json({ error: '踩失败' });
+  }
+});
+
+app.delete('/api/posts/:id/dislike', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const postId = req.params.id;
+
+    await prisma.$transaction(async (tx) => {
+      const deleted = await tx.postDislike.deleteMany({
+        where: {
+          postId,
+          userUid: req.authUser!.uid,
+        },
+      });
+
+      if (!deleted.count) {
+        return;
+      }
+
+      await tx.post.update({
+        where: { id: postId },
+        data: {
+          dislikesCount: { decrement: 1 },
+        },
+      });
+    });
+
+    const dislikesCount = await prisma.postDislike.count({ where: { postId } });
+    const updatedPost = await prisma.post.update({
+      where: { id: postId },
+      data: {
+        dislikesCount,
+      },
+    });
+
+    const hotScore = calculatePostHotScore(updatedPost);
+    await prisma.post.update({
+      where: { id: postId },
+      data: { hotScore },
+    });
+
+    res.json({ disliked: false, dislikesCount });
+  } catch (error) {
+    console.error('Undislike post error:', error);
+    res.status(500).json({ error: '取消踩失败' });
   }
 });
 
@@ -6130,9 +6307,10 @@ app.post('/api/admin/review/:type/:id/reject', requireAdmin, async (req: Authent
 
 app.patch('/api/posts/:id', requireAdmin, async (req, res) => {
   try {
-    const { commentsCount, likesCount, status } = req.body as {
+    const { commentsCount, likesCount, dislikesCount, status } = req.body as {
       commentsCount?: number;
       likesCount?: number;
+      dislikesCount?: number;
       status?: ContentStatus;
     };
 
@@ -6143,6 +6321,7 @@ app.patch('/api/posts/:id', requireAdmin, async (req, res) => {
       data: {
         commentsCount: typeof commentsCount === 'number' ? commentsCount : undefined,
         likesCount: typeof likesCount === 'number' ? likesCount : undefined,
+        dislikesCount: typeof dislikesCount === 'number' ? dislikesCount : undefined,
         status: parsedStatus || undefined,
       },
     });
@@ -6151,6 +6330,58 @@ app.patch('/api/posts/:id', requireAdmin, async (req, res) => {
   } catch (error) {
     console.error('Update post error:', error);
     res.status(500).json({ error: '更新帖子失败' });
+  }
+});
+
+app.post('/api/posts/:id/pin', requireAdmin, async (req: AuthenticatedRequest, res) => {
+  try {
+    const postId = req.params.id;
+
+    const post = await prisma.post.findUnique({
+      where: { id: postId },
+      select: { id: true, isPinned: true },
+    });
+
+    if (!post) {
+      res.status(404).json({ error: '帖子未找到' });
+      return;
+    }
+
+    const updatedPost = await prisma.post.update({
+      where: { id: postId },
+      data: { isPinned: true },
+    });
+
+    res.json({ isPinned: updatedPost.isPinned });
+  } catch (error) {
+    console.error('Pin post error:', error);
+    res.status(500).json({ error: '置顶帖子失败' });
+  }
+});
+
+app.delete('/api/posts/:id/pin', requireAdmin, async (req: AuthenticatedRequest, res) => {
+  try {
+    const postId = req.params.id;
+
+    const post = await prisma.post.findUnique({
+      where: { id: postId },
+      select: { id: true, isPinned: true },
+    });
+
+    if (!post) {
+      res.status(404).json({ error: '帖子未找到' });
+      return;
+    }
+
+    const updatedPost = await prisma.post.update({
+      where: { id: postId },
+      data: { isPinned: false },
+    });
+
+    res.json({ isPinned: updatedPost.isPinned });
+  } catch (error) {
+    console.error('Unpin post error:', error);
+    res.status(500).json({ error: '取消置顶失败' });
   }
 });
 
@@ -7911,6 +8142,70 @@ app.delete('/api/music/:docId/instrumentals/:instrumentalSongDocId', requireAdmi
   }
 });
 
+app.get('/api/music/:docId/posts', async (req: AuthenticatedRequest, res) => {
+  try {
+    const docId = req.params.docId;
+    const limit = parseInteger(req.query.limit, 20, { min: 1, max: 100 });
+    const sort = parsePostSort(req.query.sort);
+    const visibilityWhere = buildPostVisibilityWhere(req.authUser);
+
+    const where = {
+      musicDocId: docId,
+      ...visibilityWhere,
+    };
+
+    let orderBy: Array<Record<string, 'asc' | 'desc'>>;
+    if (sort === 'hot') {
+      orderBy = [{ hotScore: 'desc' }, { updatedAt: 'desc' }];
+    } else if (sort === 'recommended') {
+      orderBy = [{ commentsCount: 'desc' }, { likesCount: 'desc' }, { updatedAt: 'desc' }];
+    } else {
+      orderBy = [{ updatedAt: 'desc' }];
+    }
+
+    const posts = await prisma.post.findMany({
+      where,
+      orderBy,
+      take: limit,
+    });
+
+    const likedPostSet = new Set<string>();
+    const favoritedPostSet = new Set<string>();
+    if (req.authUser && posts.length) {
+      const [likedPosts, favoritedPosts] = await Promise.all([
+        prisma.postLike.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            postId: { in: posts.map((item) => item.id) },
+          },
+          select: { postId: true },
+        }),
+        prisma.favorite.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            targetType: 'post',
+            targetId: { in: posts.map((item) => item.id) },
+          },
+          select: { targetId: true },
+        }),
+      ]);
+      likedPosts.forEach((item) => likedPostSet.add(item.postId));
+      favoritedPosts.forEach((item) => favoritedPostSet.add(item.targetId));
+    }
+
+    res.json({
+      posts: posts.map((post) => ({
+        ...toPostResponse(post),
+        likedByMe: likedPostSet.has(post.id),
+        favoritedByMe: favoritedPostSet.has(post.id),
+      })),
+    });
+  } catch (error) {
+    console.error('Fetch music posts error:', error);
+    res.status(500).json({ error: '获取音乐关联帖子失败' });
+  }
+});
+
 app.get('/api/albums', async (req: AuthenticatedRequest, res) => {
   try {
     const platform = parseMusicPlatform(req.query.platform);
@@ -8061,6 +8356,70 @@ app.get('/api/albums/:id', async (req: AuthenticatedRequest, res) => {
   } catch (error) {
     console.error('Fetch album detail error:', error);
     res.status(500).json({ error: '获取专辑详情失败' });
+  }
+});
+
+app.get('/api/albums/:id/posts', async (req: AuthenticatedRequest, res) => {
+  try {
+    const docId = req.params.id;
+    const limit = parseInteger(req.query.limit, 20, { min: 1, max: 100 });
+    const sort = parsePostSort(req.query.sort);
+    const visibilityWhere = buildPostVisibilityWhere(req.authUser);
+
+    const where = {
+      albumDocId: docId,
+      ...visibilityWhere,
+    };
+
+    let orderBy: Array<Record<string, 'asc' | 'desc'>>;
+    if (sort === 'hot') {
+      orderBy = [{ hotScore: 'desc' }, { updatedAt: 'desc' }];
+    } else if (sort === 'recommended') {
+      orderBy = [{ commentsCount: 'desc' }, { likesCount: 'desc' }, { updatedAt: 'desc' }];
+    } else {
+      orderBy = [{ updatedAt: 'desc' }];
+    }
+
+    const posts = await prisma.post.findMany({
+      where,
+      orderBy,
+      take: limit,
+    });
+
+    const likedPostSet = new Set<string>();
+    const favoritedPostSet = new Set<string>();
+    if (req.authUser && posts.length) {
+      const [likedPosts, favoritedPosts] = await Promise.all([
+        prisma.postLike.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            postId: { in: posts.map((item) => item.id) },
+          },
+          select: { postId: true },
+        }),
+        prisma.favorite.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            targetType: 'post',
+            targetId: { in: posts.map((item) => item.id) },
+          },
+          select: { targetId: true },
+        }),
+      ]);
+      likedPosts.forEach((item) => likedPostSet.add(item.postId));
+      favoritedPosts.forEach((item) => favoritedPostSet.add(item.targetId));
+    }
+
+    res.json({
+      posts: posts.map((post) => ({
+        ...toPostResponse(post),
+        likedByMe: likedPostSet.has(post.id),
+        favoritedByMe: favoritedPostSet.has(post.id),
+      })),
+    });
+  } catch (error) {
+    console.error('Fetch album posts error:', error);
+    res.status(500).json({ error: '获取专辑关联帖子失败' });
   }
 });
 

--- a/src/pages/Forum.tsx
+++ b/src/pages/Forum.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Routes, Route, Link, useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import ReactMarkdown from 'react-markdown';
-import { MessageSquare, Heart, Share2, Plus, Clock, User as UserIcon, ArrowLeft, Save, X, Send, Edit3 } from 'lucide-react';
+import { MessageSquare, Heart, ThumbsDown, Share2, Plus, Clock, User as UserIcon, ArrowLeft, Save, X, Send, Edit3, Pin } from 'lucide-react';
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
 import MdEditor from 'react-markdown-editor-lite';
@@ -49,9 +49,12 @@ type PostItem = {
   reviewedBy?: string | null;
   reviewedAt?: string | null;
   likedByMe?: boolean;
+  dislikedByMe?: boolean;
   favoritedByMe?: boolean;
   likesCount: number;
+  dislikesCount: number;
   commentsCount: number;
+  isPinned?: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -81,7 +84,9 @@ const PostList = () => {
   const [posts, setPosts] = useState<PostItem[]>([]);
   const [sections, setSections] = useState<SectionItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const { user, isBanned } = useAuth();
+  const [pinning, setPinning] = useState<string | null>(null);
+  const { user, profile, isBanned } = useAuth();
+  const isAdmin = profile?.role === 'admin' || profile?.role === 'super_admin';
 
   useEffect(() => {
     const fetchSections = async () => {
@@ -114,6 +119,24 @@ const PostList = () => {
 
     fetchPosts();
   }, [section, sort]);
+
+  const handleTogglePin = async (postId: string, currentlyPinned: boolean) => {
+    if (!isAdmin || pinning) return;
+    try {
+      setPinning(postId);
+      if (currentlyPinned) {
+        await apiDelete<{ isPinned: boolean }>(`/api/posts/${postId}/pin`);
+        setPosts((prev) => prev.map((p) => (p.id === postId ? { ...p, isPinned: false } : p)));
+      } else {
+        await apiPost<{ isPinned: boolean }>(`/api/posts/${postId}/pin`);
+        setPosts((prev) => prev.map((p) => (p.id === postId ? { ...p, isPinned: true } : p)));
+      }
+    } catch (error) {
+      console.error('Toggle pin error:', error);
+    } finally {
+      setPinning(null);
+    }
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-12">
@@ -187,46 +210,71 @@ const PostList = () => {
       ) : posts.length > 0 ? (
         <div className="space-y-6">
           {posts.map((post) => (
-            <Link
+            <div
               key={post.id}
-              to={`/forum/${post.id}`}
-              className="block bg-white p-8 rounded-[32px] border border-gray-100 hover:border-brand-primary/20 hover:shadow-lg transition-all group"
+              className={clsx(
+                'bg-white p-8 rounded-[32px] border hover:shadow-lg transition-all group relative',
+                post.isPinned ? 'border-l-4 border-l-brand-primary border-gray-100' : 'border-gray-100 hover:border-brand-primary/20',
+              )}
             >
-              <div className="flex items-center gap-3 mb-4">
-                <span className="px-2 py-1 bg-brand-primary/10 text-brand-primary text-[10px] font-bold uppercase tracking-wider rounded">
-                  {sections.find((s) => s.id === post.section)?.name || post.section}
-                </span>
-                <span className="text-gray-300">|</span>
-                <span className="text-gray-400 text-xs flex items-center gap-1">
-                  <Clock size={12} /> {formatDate(post.updatedAt, 'yyyy-MM-dd')}
-                </span>
-                {post.status && post.status !== 'published' && (
-                  <span className={clsx(
-                    'px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider',
-                    post.status === 'pending'
-                      ? 'bg-amber-100 text-amber-700'
-                      : post.status === 'rejected'
-                        ? 'bg-red-100 text-red-700'
-                        : 'bg-gray-100 text-gray-600',
-                  )}>
-                    {getStatusText(post.status)}
+              <Link to={`/forum/${post.id}`} className="block">
+                <div className="flex items-center gap-3 mb-4">
+                  {post.isPinned && (
+                    <span className="flex items-center gap-1 px-2 py-1 bg-brand-primary/10 text-brand-primary text-[10px] font-bold uppercase tracking-wider rounded">
+                      <Pin size={10} /> 已置顶
+                    </span>
+                  )}
+                  <span className="px-2 py-1 bg-brand-primary/10 text-brand-primary text-[10px] font-bold uppercase tracking-wider rounded">
+                    {sections.find((s) => s.id === post.section)?.name || post.section}
                   </span>
-                )}
-              </div>
-              <h3 className="text-2xl font-serif font-bold mb-3 group-hover:text-brand-primary transition-colors">{post.title}</h3>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-6 text-gray-400 text-sm">
-                  <span className="flex items-center gap-1.5"><Heart size={16} /> {post.likesCount || 0}</span>
-                  <span className="flex items-center gap-1.5"><MessageSquare size={16} /> {post.commentsCount || 0}</span>
+                  <span className="text-gray-300">|</span>
+                  <span className="text-gray-400 text-xs flex items-center gap-1">
+                    <Clock size={12} /> {formatDate(post.updatedAt, 'yyyy-MM-dd')}
+                  </span>
+                  {post.status && post.status !== 'published' && (
+                    <span className={clsx(
+                      'px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider',
+                      post.status === 'pending'
+                        ? 'bg-amber-100 text-amber-700'
+                        : post.status === 'rejected'
+                          ? 'bg-red-100 text-red-700'
+                          : 'bg-gray-100 text-gray-600',
+                    )}>
+                      {getStatusText(post.status)}
+                    </span>
+                  )}
                 </div>
-                <div className="flex items-center gap-2">
-                  <div className="w-6 h-6 rounded-full bg-gray-200 overflow-hidden">
-                    <UserIcon size={14} className="m-auto text-gray-400" />
+                <h3 className="text-2xl font-serif font-bold mb-3 group-hover:text-brand-primary transition-colors">{post.title}</h3>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-6 text-gray-400 text-sm">
+                    <span className="flex items-center gap-1.5"><Heart size={16} /> {post.likesCount || 0}</span>
+                    <span className="flex items-center gap-1.5"><ThumbsDown size={16} /> {post.dislikesCount || 0}</span>
+                    <span className="flex items-center gap-1.5"><MessageSquare size={16} /> {post.commentsCount || 0}</span>
                   </div>
-                  <span className="text-xs text-gray-500">作者 ID: {post.authorUid?.substring(0, 6)}</span>
+                  <div className="flex items-center gap-2">
+                    <div className="w-6 h-6 rounded-full bg-gray-200 overflow-hidden">
+                      <UserIcon size={14} className="m-auto text-gray-400" />
+                    </div>
+                    <span className="text-xs text-gray-500">作者 ID: {post.authorUid?.substring(0, 6)}</span>
+                  </div>
                 </div>
-              </div>
-            </Link>
+              </Link>
+              {isAdmin && (
+                <button
+                  onClick={() => handleTogglePin(post.id, !!post.isPinned)}
+                  disabled={pinning === post.id}
+                  className={clsx(
+                    'absolute top-4 right-4 px-3 py-1.5 rounded-full text-xs font-medium transition-all',
+                    post.isPinned
+                      ? 'bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20'
+                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+                    pinning === post.id && 'opacity-50 cursor-not-allowed',
+                  )}
+                >
+                  {pinning === post.id ? '处理中...' : post.isPinned ? '取消置顶' : '置顶'}
+                </button>
+              )}
+            </div>
           ))}
         </div>
       ) : (
@@ -250,7 +298,10 @@ const PostDetail = () => {
   const [submittingReview, setSubmittingReview] = useState(false);
   const [favoriting, setFavoriting] = useState(false);
   const [liking, setLiking] = useState(false);
-  const { user, isBanned } = useAuth();
+  const [disliking, setDisliking] = useState(false);
+  const [pinning, setPinning] = useState(false);
+  const { user, profile, isBanned } = useAuth();
+  const isAdmin = profile?.role === 'admin' || profile?.role === 'super_admin';
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -345,6 +396,25 @@ const PostDetail = () => {
     }
   };
 
+  const handleToggleDislike = async () => {
+    if (!post || !postId || !user || disliking) return;
+    setDisliking(true);
+    try {
+      if (post.dislikedByMe) {
+        const data = await apiDelete<{ disliked: boolean; dislikesCount: number }>(`/api/posts/${postId}/dislike`);
+        setPost((prev) => (prev ? { ...prev, dislikedByMe: data.disliked, dislikesCount: data.dislikesCount } : prev));
+      } else {
+        const data = await apiPost<{ disliked: boolean; dislikesCount: number }>(`/api/posts/${postId}/dislike`);
+        setPost((prev) => (prev ? { ...prev, dislikedByMe: data.disliked, dislikesCount: data.dislikesCount } : prev));
+      }
+    } catch (error) {
+      console.error('Error toggling dislike:', error);
+      alert('操作失败，请稍后重试');
+    } finally {
+      setDisliking(false);
+    }
+  };
+
   const handleToggleFavorite = async () => {
     if (!post || !postId || !user || favoriting) return;
     setFavoriting(true);
@@ -376,6 +446,25 @@ const PostDetail = () => {
       alert('提交审核失败，请稍后重试');
     } finally {
       setSubmittingReview(false);
+    }
+  };
+
+  const handleTogglePin = async () => {
+    if (!post || !postId || !isAdmin || pinning) return;
+    setPinning(true);
+    try {
+      if (post.isPinned) {
+        await apiDelete<{ isPinned: boolean }>(`/api/posts/${postId}/pin`);
+        setPost((prev) => (prev ? { ...prev, isPinned: false } : prev));
+      } else {
+        await apiPost<{ isPinned: boolean }>(`/api/posts/${postId}/pin`);
+        setPost((prev) => (prev ? { ...prev, isPinned: true } : prev));
+      }
+    } catch (error) {
+      console.error('Error toggling pin:', error);
+      alert('操作失败，请稍后重试');
+    } finally {
+      setPinning(false);
     }
   };
 
@@ -464,6 +553,17 @@ const PostDetail = () => {
             <Heart size={20} /> {post.likesCount || 0}
           </button>
           <button
+            onClick={handleToggleDislike}
+            disabled={!user || disliking}
+            className={clsx(
+              'flex items-center gap-2 transition-colors',
+              post.dislikedByMe ? 'text-orange-500' : 'text-gray-400 hover:text-orange-500',
+              (!user || disliking) && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            <ThumbsDown size={20} /> {post.dislikesCount || 0}
+          </button>
+          <button
             onClick={handleToggleFavorite}
             disabled={!user || favoriting}
             className={clsx(
@@ -481,6 +581,19 @@ const PostDetail = () => {
             <Link to={`/forum/${post.id}/edit`} className="flex items-center gap-2 text-gray-400 hover:text-brand-primary transition-colors">
               <Edit3 size={20} /> 编辑
             </Link>
+          )}
+          {isAdmin && (
+            <button
+              onClick={handleTogglePin}
+              disabled={pinning}
+              className={clsx(
+                'flex items-center gap-2 transition-colors',
+                post.isPinned ? 'text-brand-primary' : 'text-gray-400 hover:text-brand-primary',
+                pinning && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              <Pin size={20} /> {post.isPinned ? '已置顶' : '置顶'}
+            </button>
           )}
           {canSubmitReview && (
             <button
@@ -594,6 +707,9 @@ const PostEditor = () => {
   const isEditing = Boolean(postId);
   const navigate = useNavigate();
   const { user, isBanned, loading: authLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const musicDocIdParam = searchParams.get('musicDocId');
+  const musicTitleParam = searchParams.get('musicTitle');
   const [sections, setSections] = useState<SectionItem[]>([]);
   const [formData, setFormData] = useState({
     title: '',
@@ -610,16 +726,28 @@ const PostEditor = () => {
         const data = await apiGet<{ sections: SectionItem[] }>('/api/sections');
         const fetchedSections = data.sections || [];
         setSections(fetchedSections);
-        if (fetchedSections.length > 0) {
-          setFormData((prev) => (prev.section ? prev : { ...prev, section: fetchedSections[0].id }));
+
+        let defaultSection = fetchedSections[0]?.id || '';
+        let defaultContent = '';
+
+        if (musicDocIdParam && musicTitleParam) {
+          defaultSection = 'music';
+          defaultContent = `\n\n---\n*本文为《${decodeURIComponent(musicTitleParam)}》的乐评*\n`;
         }
+
+        setFormData((prev) => ({
+          title: prev.title,
+          section: prev.section || defaultSection,
+          content: prev.content || defaultContent,
+          tags: prev.tags,
+        }));
       } catch (error) {
         console.error('Error fetching sections:', error);
       }
     };
 
     fetchSections();
-  }, []);
+  }, [musicDocIdParam, musicTitleParam]);
 
   useEffect(() => {
     const fetchEditingPost = async () => {
@@ -666,13 +794,17 @@ const PostEditor = () => {
     setSavingMode(status);
 
     try {
-      const payload = {
+      const payload: Record<string, unknown> = {
         title: formData.title,
         section: formData.section,
         content: formData.content,
         tags: formData.tags.split(',').map((t) => t.trim()).filter(Boolean),
         status,
       };
+
+      if (!isEditing && musicDocIdParam) {
+        payload.musicDocId = musicDocIdParam;
+      }
 
       const data = isEditing && postId
         ? await apiPut<{ post: PostItem }>(`/api/posts/${postId}`, payload)


### PR DESCRIPTION
## Summary

- **帖子踩功能**：用户可以对帖子踩（类似点赞的反向操作），防止重复踩
- **帖子置顶功能**：管理员可以将帖子置顶，置顶帖在列表中优先显示
- 新增 `PostDislike` 数据模型记录踩的用户
- 新增 `dislikesCount` 和 `isPinned` 字段到 `Post` 模型

## Changes

### Database (Prisma)
- `Post` 模型新增 `dislikesCount` (Int) 和 `isPinned` (Boolean) 字段
- 新增 `PostDislike` 模型，与 `PostLike` 结构一致

### Backend API
- `POST /api/posts/:id/dislike` - 踩（toggle）
- `DELETE /api/posts/:id/dislike` - 取消踩
- `POST /api/posts/:id/pin` - 置顶（仅管理员）
- `DELETE /api/posts/:id/pin` - 取消置顶（仅管理员）
- `GET /api/posts` 和 `GET /api/posts/:id` 返回值新增 `dislikedByMe` 和 `isPinned`

### Frontend
- PostList 显示置顶标识（Pin 图标 + 左边框高亮）
- PostList 管理员可置顶/取消置顶帖子
- PostDetail 点赞/踩按钮并列显示
- PostDetail 管理员显示置顶按钮

## Test Checklist

- [ ] 登录用户可以对帖子点赞/踩
- [ ] 重复点赞/踩自动切换状态
- [ ] 非管理员无法调用置顶 API（返回 403）
- [ ] 置顶帖在列表中优先显示
- [ ] 帖子详情页显示正确的点赞/踩数量

## Migration

部署后需要运行：
```bash
npm run db:generate
npm run db:migrate
```