### PR TITLE
feat(admin): add edit-lock and gallery publish workflows

### DIFF
--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -344,6 +344,39 @@ npm run db:seed
 - 提示方式统一为顶部 Toast（不再弹浏览器 `alert`）
 - 入口由 `src/components/Toast.tsx` 提供，并在 `src/main.tsx` 全局挂载
 
+### 6.6 编辑锁与图集发布流说明（v2.9+）
+
+本次发布补齐后台协作与图集生命周期能力，且你已确认当前为"无旧数据迁移"场景，可直接按当前流程部署。
+
+**数据库变更（已包含在 `db:deploy` 中）：**
+
+| 表名 | 变更类型 | 说明 |
+|------|---------|------|
+| `Gallery` | 新增列 | `published` Boolean，默认 `false` |
+| `Gallery` | 新增列 | `publishedAt` DateTime，可空 |
+| `Gallery` | 新增索引 | `published + updatedAt` 复合索引 |
+| `EditLock` | 新建表 | 记录级编辑锁（collection + recordId 唯一） |
+
+**后端 API 变更：**
+
+| 端点 | 方法 | 功能 | 权限 |
+|------|------|------|------|
+| `/api/galleries/:id` | PATCH | 更新图集标题/描述/标签 | 作者或管理员 |
+| `/api/galleries/:id/publish` | PATCH | 发布/取消发布图集 | 作者或管理员 |
+| `/api/galleries/:id/images` | POST | 追加图片（基于 UploadSession + assetIds） | 作者或管理员 |
+| `/api/galleries/:id/images/:imageId` | DELETE | 删除单张图片（至少保留一张） | 作者或管理员 |
+| `/api/galleries/:id/images/reorder` | PATCH | 批量重排图片 | 作者或管理员 |
+| `/api/admin/locks` | POST | 申请编辑锁（支持续期、管理员强制接管） | 登录用户 |
+| `/api/admin/locks/:id/renew` | PATCH | 编辑锁续期 | 锁持有者或管理员 |
+| `/api/admin/locks` | GET | 编辑锁列表 | 管理员 |
+| `/api/admin/locks/:id` | DELETE | 释放编辑锁 | 锁持有者或管理员 |
+| `/api/admin/locks/:collection/:recordId` | DELETE | 强制释放指定记录锁 | 管理员 |
+
+**图集访问策略更新：**
+
+- `GET /api/galleries`：游客仅返回已发布图集；作者可见自己的草稿；管理员可见全部。
+- `GET /api/galleries/:id`：未发布图集仅作者和管理员可见。
+
 ---
 
 ## 7. 构建并启动服务
@@ -636,6 +669,68 @@ curl http://127.0.0.1:3000/api/music/<platformSongId>
 - 粘贴内容为完整站内 URL（含域名）
 - 链接可在新标签页直接打开对应内容
 - 在移动端和桌面端都可触发复制逻辑
+
+### 11.5 编辑锁与图集发布流验证（v2.9+）
+
+#### 11.5.1 图集发布流验证
+
+```bash
+# 1) 获取图集列表（游客只会看到已发布图集）
+curl http://127.0.0.1:3000/api/galleries
+
+# 2) 切换发布状态（需登录，作者或管理员）
+curl -X PATCH http://127.0.0.1:3000/api/galleries/<galleryId>/publish \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"published":true}'
+
+# 3) 更新图集基础信息
+curl -X PATCH http://127.0.0.1:3000/api/galleries/<galleryId> \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"title":"新标题","description":"新描述","tags":["Live","2026"]}'
+
+# 4) 图片重排（imageIds 需来自图集详情返回）
+curl -X PATCH http://127.0.0.1:3000/api/galleries/<galleryId>/images/reorder \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"imageIds":["<imageId1>","<imageId2>","<imageId3>"]}'
+```
+
+验证点：
+
+- 游客访问未发布图集详情返回 `403`。
+- 作者与管理员可访问未发布图集并可执行编辑/发布操作。
+- 删除图片时，图集至少保留 1 张图片。
+
+#### 11.5.2 编辑锁验证
+
+```bash
+# 1) 申请编辑锁
+curl -X POST http://127.0.0.1:3000/api/admin/locks \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"collection":"galleries","recordId":"<galleryId>","ttlMinutes":15}'
+
+# 2) 续期编辑锁
+curl -X PATCH http://127.0.0.1:3000/api/admin/locks/<lockId>/renew \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"ttlMinutes":30}'
+
+# 3) 管理员查看锁列表
+curl http://127.0.0.1:3000/api/admin/locks -b cookie.txt -c cookie.txt
+
+# 4) 管理员强制释放指定记录锁
+curl -X DELETE http://127.0.0.1:3000/api/admin/locks/galleries/<galleryId> \
+  -b cookie.txt -c cookie.txt
+```
+
+验证点：
+
+- 同一记录重复申请锁时，非持有者返回 `409` 并包含锁信息。
+- 管理员在 `force=true` 时可以接管非本人锁。
+- 过期锁会被自动清理，不会长期阻塞编辑。
 
 ---
 

--- a/prisma/migrate.sql
+++ b/prisma/migrate.sql
@@ -1130,3 +1130,60 @@ CREATE TABLE IF NOT EXISTS `SongInstrumentalRelation` (
   CONSTRAINT `SongInstrumentalRelation_songDocId_fkey` FOREIGN KEY (`songDocId`) REFERENCES `MusicTrack` (`docId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `SongInstrumentalRelation_targetSongDocId_fkey` FOREIGN KEY (`targetSongDocId`) REFERENCES `MusicTrack` (`docId`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @has_gallery_published := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'Gallery' AND COLUMN_NAME = 'published'
+);
+SET @sql := IF(
+  @has_gallery_published = 0,
+  'ALTER TABLE `Gallery` ADD COLUMN `published` tinyint(1) NOT NULL DEFAULT 0',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_gallery_published_at := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'Gallery' AND COLUMN_NAME = 'publishedAt'
+);
+SET @sql := IF(
+  @has_gallery_published_at = 0,
+  'ALTER TABLE `Gallery` ADD COLUMN `publishedAt` datetime(3) DEFAULT NULL',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_gallery_published_idx := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'Gallery' AND INDEX_NAME = 'Gallery_published_updatedAt_idx'
+);
+SET @sql := IF(
+  @has_gallery_published_idx = 0,
+  'CREATE INDEX `Gallery_published_updatedAt_idx` ON `Gallery` (`published`, `updatedAt`)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS `EditLock` (
+  `id` varchar(191) NOT NULL,
+  `collection` varchar(191) NOT NULL,
+  `recordId` varchar(191) NOT NULL,
+  `userId` varchar(191) NOT NULL,
+  `username` varchar(191) NOT NULL,
+  `createdAt` datetime(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `expiresAt` datetime(3) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `EditLock_collection_recordId_key` (`collection`,`recordId`),
+  KEY `EditLock_userId_idx` (`userId`),
+  KEY `EditLock_expiresAt_idx` (`expiresAt`),
+  CONSTRAINT `EditLock_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User` (`uid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,7 @@ model User {
   browsingHistories BrowsingHistory[]
   uploadSessions UploadSession[]
   mediaAssets   MediaAsset[]
+  editLocks     EditLock[]
 
   @@index([status, createdAt])
   @@index([wechatUnionId])
@@ -417,12 +418,30 @@ model Gallery {
   authorUid  String
   authorName String
   tags       Json?
+  published  Boolean        @default(false)
+  publishedAt DateTime?
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
   author     User           @relation("UserGalleries", fields: [authorUid], references: [uid], onDelete: Cascade)
   images     GalleryImage[]
 
   @@index([createdAt])
+  @@index([published, updatedAt])
+}
+
+model EditLock {
+  id         String   @id @default(cuid())
+  collection String
+  recordId   String
+  userId     String
+  username   String
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime
+  user       User     @relation(fields: [userId], references: [uid], onDelete: Cascade)
+
+  @@unique([collection, recordId])
+  @@index([userId])
+  @@index([expiresAt])
 }
 
 model UploadSession {

--- a/server.ts
+++ b/server.ts
@@ -847,6 +847,33 @@ function parseAssetIdList(value: unknown) {
   return [...deduped];
 }
 
+const EDIT_LOCK_COLLECTION_ALLOWLIST = new Set([
+  'songs',
+  'albums',
+  'galleries',
+  'activities',
+  'wiki',
+  'posts',
+]);
+
+function normalizeEditLockCollection(value: unknown) {
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return '';
+  if (EDIT_LOCK_COLLECTION_ALLOWLIST.has(normalized)) return normalized;
+  return '';
+}
+
+function normalizeEditLockRecordId(value: unknown) {
+  if (typeof value !== 'string') return '';
+  const normalized = value.trim();
+  if (!normalized) return '';
+  if (normalized.length > 191) {
+    return normalized.slice(0, 191);
+  }
+  return normalized;
+}
+
 function createUploadSessionExpiresAt() {
   return new Date(Date.now() + UPLOAD_SESSION_TTL_MINUTES * 60 * 1000);
 }
@@ -2014,6 +2041,19 @@ function canViewPost(post: { status: ContentStatus; authorUid: string }, authUse
   return post.authorUid === authUser.uid;
 }
 
+function canViewGallery(gallery: { published: boolean; authorUid: string }, authUser?: ApiUser) {
+  if (gallery.published) return true;
+  if (!authUser) return false;
+  if (isAdminRole(authUser.role)) return true;
+  return gallery.authorUid === authUser.uid;
+}
+
+function canManageGallery(gallery: { authorUid: string }, authUser?: ApiUser) {
+  if (!authUser) return false;
+  if (isAdminRole(authUser.role)) return true;
+  return gallery.authorUid === authUser.uid;
+}
+
 function buildWikiVisibilityWhere(authUser?: ApiUser) {
   if (!authUser) {
     return { status: 'published' as ContentStatus };
@@ -2482,6 +2522,8 @@ function toGalleryResponse(gallery: {
   authorUid: string;
   authorName: string;
   tags: unknown;
+  published: boolean;
+  publishedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
   images: {
@@ -2507,17 +2549,36 @@ function toGalleryResponse(gallery: {
     authorUid: gallery.authorUid,
     authorName: gallery.authorName,
     tags: serializeTags(gallery.tags),
+    published: gallery.published,
+    publishedAt: gallery.publishedAt ? gallery.publishedAt.toISOString() : null,
     createdAt: gallery.createdAt.toISOString(),
     updatedAt: gallery.updatedAt.toISOString(),
     images: gallery.images
       .sort((a, b) => a.sortOrder - b.sortOrder)
       .map((image) => ({
+        id: image.id,
         assetId: image.assetId || image.asset?.id || null,
         url: image.asset?.publicUrl || image.url,
         name: image.asset?.fileName || image.name,
         mimeType: image.asset?.mimeType || null,
         sizeBytes: image.asset?.sizeBytes || null,
       })),
+  };
+}
+
+function toEditLockResponse(lock: {
+  id: string;
+  collection: string;
+  recordId: string;
+  userId: string;
+  username: string;
+  createdAt: Date;
+  expiresAt: Date;
+}) {
+  return {
+    ...lock,
+    createdAt: lock.createdAt.toISOString(),
+    expiresAt: lock.expiresAt.toISOString(),
   };
 }
 
@@ -6451,9 +6512,21 @@ app.delete('/api/posts/:id', requireAdmin, async (req, res) => {
   }
 });
 
-app.get('/api/galleries', async (_req, res) => {
+app.get('/api/galleries', async (req: AuthenticatedRequest, res) => {
   try {
+    const visibilityWhere = req.authUser
+      ? (isAdminRole(req.authUser.role)
+          ? {}
+          : {
+              OR: [
+                { published: true },
+                { authorUid: req.authUser.uid },
+              ],
+            })
+      : { published: true };
+
     const galleries = await prisma.gallery.findMany({
+      where: visibilityWhere,
       include: {
         images: {
           include: {
@@ -6473,7 +6546,7 @@ app.get('/api/galleries', async (_req, res) => {
   }
 });
 
-app.get('/api/galleries/:id', async (req, res) => {
+app.get('/api/galleries/:id', async (req: AuthenticatedRequest, res) => {
   try {
     const gallery = await prisma.gallery.findUnique({
       where: { id: req.params.id },
@@ -6489,6 +6562,11 @@ app.get('/api/galleries/:id', async (req, res) => {
 
     if (!gallery) {
       res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canViewGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '该图集尚未发布' });
       return;
     }
 
@@ -7044,6 +7122,605 @@ app.post('/api/galleries', requireAuth, requireActiveUser, async (req: Authentic
   } catch (error) {
     console.error('Create gallery error:', error);
     res.status(500).json({ error: '创建图集失败' });
+  }
+});
+
+app.patch('/api/galleries/:id', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const gallery = await prisma.gallery.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        authorUid: true,
+      },
+    });
+
+    if (!gallery) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canManageGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '无权限编辑该图集' });
+      return;
+    }
+
+    const title = typeof req.body?.title === 'string' ? req.body.title.trim() : undefined;
+    const description = typeof req.body?.description === 'string' ? req.body.description.trim() : undefined;
+    const tags = req.body?.tags !== undefined ? normalizeTagList(req.body.tags) : undefined;
+
+    const data: {
+      title?: string;
+      description?: string;
+      tags?: string[];
+    } = {};
+
+    if (title !== undefined && title.length > 0) {
+      data.title = title;
+    }
+    if (description !== undefined) {
+      data.description = description || '无描述';
+    }
+    if (tags !== undefined) {
+      data.tags = tags;
+    }
+
+    if (!Object.keys(data).length) {
+      res.status(400).json({ error: '没有可更新的字段' });
+      return;
+    }
+
+    const updated = await prisma.gallery.update({
+      where: { id: req.params.id },
+      data,
+      include: {
+        images: {
+          include: {
+            asset: true,
+          },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    res.json({ gallery: toGalleryResponse(updated) });
+  } catch (error) {
+    console.error('Update gallery error:', error);
+    res.status(500).json({ error: '更新图集失败' });
+  }
+});
+
+app.patch('/api/galleries/:id/publish', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const gallery = await prisma.gallery.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        authorUid: true,
+        published: true,
+      },
+    });
+
+    if (!gallery) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canManageGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '无权限修改图集发布状态' });
+      return;
+    }
+
+    const nextPublished = parseBoolean(req.body?.published, !gallery.published);
+    const updated = await prisma.gallery.update({
+      where: { id: req.params.id },
+      data: {
+        published: nextPublished,
+        publishedAt: nextPublished ? new Date() : null,
+      },
+      include: {
+        images: {
+          include: {
+            asset: true,
+          },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    res.json({ gallery: toGalleryResponse(updated) });
+  } catch (error) {
+    console.error('Update gallery publish status error:', error);
+    res.status(500).json({ error: '修改图集发布状态失败' });
+  }
+});
+
+app.post('/api/galleries/:id/images', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const gallery = await prisma.gallery.findUnique({
+      where: { id: req.params.id },
+      include: {
+        images: {
+          select: {
+            id: true,
+            sortOrder: true,
+          },
+        },
+      },
+    });
+
+    if (!gallery) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canManageGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '无权限编辑该图集' });
+      return;
+    }
+
+    const assetIds = parseAssetIdList(req.body?.assetIds);
+    if (!assetIds.length) {
+      res.status(400).json({ error: '请提供至少一个图片资源' });
+      return;
+    }
+
+    const uploadSessionId = typeof req.body?.uploadSessionId === 'string' ? req.body.uploadSessionId.trim() : '';
+    if (uploadSessionId) {
+      const session = await prisma.uploadSession.findUnique({
+        where: { id: uploadSessionId },
+        select: {
+          id: true,
+          ownerUid: true,
+          status: true,
+          expiresAt: true,
+        },
+      });
+      if (!session || session.ownerUid !== req.authUser!.uid) {
+        res.status(400).json({ error: '上传会话不存在' });
+        return;
+      }
+      if (session.status === 'expired' || isUploadSessionExpired(session.expiresAt)) {
+        if (session.status !== 'expired') {
+          await prisma.uploadSession.update({
+            where: { id: session.id },
+            data: { status: 'expired' },
+          });
+        }
+        res.status(410).json({ error: '上传会话已过期，请重新上传' });
+        return;
+      }
+      if (session.status !== 'finalized') {
+        res.status(400).json({ error: '请先完成上传会话' });
+        return;
+      }
+    }
+
+    const assets = await prisma.mediaAsset.findMany({
+      where: {
+        id: { in: assetIds },
+        ownerUid: req.authUser!.uid,
+        status: 'ready',
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (assets.length !== assetIds.length) {
+      res.status(400).json({ error: '包含无效或无权限的图片资源' });
+      return;
+    }
+
+    const assetMap = new Map(assets.map((asset) => [asset.id, asset]));
+    const orderedAssets = assetIds
+      .map((id) => assetMap.get(id))
+      .filter((asset): asset is typeof assets[number] => Boolean(asset));
+    const baseSortOrder = gallery.images.length
+      ? Math.max(...gallery.images.map((item) => item.sortOrder)) + 1
+      : 0;
+
+    await prisma.gallery.update({
+      where: { id: gallery.id },
+      data: {
+        images: {
+          create: orderedAssets.map((asset, index) => ({
+            assetId: asset.id,
+            url: asset.publicUrl,
+            name: asset.fileName || `image-${baseSortOrder + index + 1}`,
+            sortOrder: baseSortOrder + index,
+          })),
+        },
+      },
+    });
+
+    const updated = await prisma.gallery.findUnique({
+      where: { id: gallery.id },
+      include: {
+        images: {
+          include: {
+            asset: true,
+          },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    if (updated) {
+      try {
+        await enqueueGalleryImageEmbeddings(
+          prisma,
+          updated.images.map((image) => image.id),
+        );
+      } catch (error) {
+        console.error('Enqueue gallery image embeddings error:', error);
+      }
+
+      res.json({ gallery: toGalleryResponse(updated) });
+      return;
+    }
+
+    res.status(404).json({ error: '图集不存在' });
+  } catch (error) {
+    console.error('Append gallery images error:', error);
+    res.status(500).json({ error: '追加图集图片失败' });
+  }
+});
+
+app.delete('/api/galleries/:id/images/:imageId', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const gallery = await prisma.gallery.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        authorUid: true,
+      },
+    });
+
+    if (!gallery) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canManageGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '无权限编辑该图集' });
+      return;
+    }
+
+    const image = await prisma.galleryImage.findUnique({
+      where: { id: req.params.imageId },
+      select: {
+        id: true,
+        galleryId: true,
+        assetId: true,
+        url: true,
+      },
+    });
+
+    if (!image || image.galleryId !== gallery.id) {
+      res.status(404).json({ error: '图片不存在' });
+      return;
+    }
+
+    const imageCount = await prisma.galleryImage.count({ where: { galleryId: gallery.id } });
+    if (imageCount <= 1) {
+      res.status(400).json({ error: '图集至少需要保留一张图片' });
+      return;
+    }
+
+    await prisma.galleryImage.delete({ where: { id: image.id } });
+
+    if (image.assetId) {
+      const linked = await prisma.galleryImage.count({ where: { assetId: image.assetId } });
+      if (linked === 0) {
+        const asset = await prisma.mediaAsset.findUnique({ where: { id: image.assetId } });
+        if (asset) {
+          await safeDeleteUploadFileByStorageKey(asset.storageKey);
+          await prisma.mediaAsset.update({
+            where: { id: asset.id },
+            data: { status: 'deleted' },
+          });
+        }
+      }
+    } else {
+      await safeDeleteUploadFileByUrl(image.url);
+    }
+
+    const remaining = await prisma.galleryImage.findMany({
+      where: { galleryId: gallery.id },
+      orderBy: { sortOrder: 'asc' },
+      select: { id: true },
+    });
+
+    await Promise.all(
+      remaining.map((item, index) =>
+        prisma.galleryImage.update({
+          where: { id: item.id },
+          data: { sortOrder: index },
+        }),
+      ),
+    );
+
+    const updated = await prisma.gallery.findUnique({
+      where: { id: gallery.id },
+      include: {
+        images: {
+          include: {
+            asset: true,
+          },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    if (!updated) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    res.json({ gallery: toGalleryResponse(updated) });
+  } catch (error) {
+    console.error('Delete gallery image error:', error);
+    res.status(500).json({ error: '删除图集图片失败' });
+  }
+});
+
+app.patch('/api/galleries/:id/images/reorder', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const gallery = await prisma.gallery.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        authorUid: true,
+      },
+    });
+
+    if (!gallery) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    if (!canManageGallery(gallery, req.authUser)) {
+      res.status(403).json({ error: '无权限编辑该图集' });
+      return;
+    }
+
+    const imageIdsRaw = Array.isArray(req.body?.imageIds) ? req.body.imageIds : [];
+    const imageIds = imageIdsRaw
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (!imageIds.length) {
+      res.status(400).json({ error: '请提供图片排序列表' });
+      return;
+    }
+
+    const existing = await prisma.galleryImage.findMany({
+      where: { galleryId: gallery.id },
+      select: { id: true },
+    });
+    const existingIds = existing.map((item) => item.id);
+    if (existingIds.length !== imageIds.length) {
+      res.status(400).json({ error: '排序列表与当前图片数量不一致' });
+      return;
+    }
+    const existingSet = new Set(existingIds);
+    if (imageIds.some((id) => !existingSet.has(id))) {
+      res.status(400).json({ error: '排序列表包含无效图片' });
+      return;
+    }
+
+    await prisma.$transaction(
+      imageIds.map((imageId, index) =>
+        prisma.galleryImage.update({
+          where: { id: imageId },
+          data: { sortOrder: index },
+        }),
+      ),
+    );
+
+    const updated = await prisma.gallery.findUnique({
+      where: { id: gallery.id },
+      include: {
+        images: {
+          include: {
+            asset: true,
+          },
+          orderBy: { sortOrder: 'asc' },
+        },
+      },
+    });
+
+    if (!updated) {
+      res.status(404).json({ error: '图集不存在' });
+      return;
+    }
+
+    res.json({ gallery: toGalleryResponse(updated) });
+  } catch (error) {
+    console.error('Reorder gallery images error:', error);
+    res.status(500).json({ error: '重排图集图片失败' });
+  }
+});
+
+app.post('/api/admin/locks', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    await prisma.editLock.deleteMany({
+      where: {
+        expiresAt: {
+          lt: new Date(),
+        },
+      },
+    });
+
+    const collection = normalizeEditLockCollection(req.body?.collection);
+    const recordId = normalizeEditLockRecordId(req.body?.recordId);
+    if (!collection || !recordId) {
+      res.status(400).json({ error: '缺少有效的锁定目标' });
+      return;
+    }
+
+    const ttlMinutes = parseInteger(req.body?.ttlMinutes, 15, { min: 3, max: 120 });
+    const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000);
+    const force = parseBoolean(req.body?.force, false);
+
+    const existing = await prisma.editLock.findUnique({
+      where: {
+        collection_recordId: {
+          collection,
+          recordId,
+        },
+      },
+    });
+
+    if (existing && existing.userId !== req.authUser!.uid) {
+      const isExpired = existing.expiresAt.getTime() <= Date.now();
+      if (!isExpired && !(force && isAdminRole(req.authUser!.role))) {
+        res.status(409).json({
+          error: '该记录正在被其他用户编辑',
+          lock: toEditLockResponse(existing),
+        });
+        return;
+      }
+
+      const takenOver = await prisma.editLock.update({
+        where: { id: existing.id },
+        data: {
+          userId: req.authUser!.uid,
+          username: req.authUser!.displayName,
+          expiresAt,
+        },
+      });
+
+      res.json({ lock: toEditLockResponse(takenOver), acquired: true, takeover: true });
+      return;
+    }
+
+    if (existing && existing.userId === req.authUser!.uid) {
+      const renewed = await prisma.editLock.update({
+        where: { id: existing.id },
+        data: {
+          username: req.authUser!.displayName,
+          expiresAt,
+        },
+      });
+      res.json({ lock: toEditLockResponse(renewed), acquired: true, renewed: true });
+      return;
+    }
+
+    const created = await prisma.editLock.create({
+      data: {
+        collection,
+        recordId,
+        userId: req.authUser!.uid,
+        username: req.authUser!.displayName,
+        expiresAt,
+      },
+    });
+
+    res.status(201).json({ lock: toEditLockResponse(created), acquired: true });
+  } catch (error) {
+    console.error('Acquire edit lock error:', error);
+    res.status(500).json({ error: '申请编辑锁失败' });
+  }
+});
+
+app.patch('/api/admin/locks/:id/renew', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const lock = await prisma.editLock.findUnique({ where: { id: req.params.id } });
+    if (!lock) {
+      res.status(404).json({ error: '编辑锁不存在' });
+      return;
+    }
+
+    const canManage = lock.userId === req.authUser!.uid || isAdminRole(req.authUser!.role);
+    if (!canManage) {
+      res.status(403).json({ error: '无权限续期该编辑锁' });
+      return;
+    }
+
+    const ttlMinutes = parseInteger(req.body?.ttlMinutes, 15, { min: 3, max: 120 });
+    const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000);
+    const renewed = await prisma.editLock.update({
+      where: { id: lock.id },
+      data: {
+        expiresAt,
+        username: lock.userId === req.authUser!.uid ? req.authUser!.displayName : lock.username,
+      },
+    });
+
+    res.json({ lock: toEditLockResponse(renewed), renewed: true });
+  } catch (error) {
+    console.error('Renew edit lock error:', error);
+    res.status(500).json({ error: '续期编辑锁失败' });
+  }
+});
+
+app.get('/api/admin/locks', requireAdmin, async (_req, res) => {
+  try {
+    await prisma.editLock.deleteMany({
+      where: {
+        expiresAt: {
+          lt: new Date(),
+        },
+      },
+    });
+
+    const locks = await prisma.editLock.findMany({
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 200,
+    });
+
+    res.json({ locks: locks.map(toEditLockResponse) });
+  } catch (error) {
+    console.error('Fetch edit locks error:', error);
+    res.status(500).json({ error: '获取编辑锁列表失败' });
+  }
+});
+
+app.delete('/api/admin/locks/:id', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const lock = await prisma.editLock.findUnique({ where: { id: req.params.id } });
+    if (!lock) {
+      res.json({ success: true });
+      return;
+    }
+
+    const canManage = lock.userId === req.authUser!.uid || isAdminRole(req.authUser!.role);
+    if (!canManage) {
+      res.status(403).json({ error: '无权限释放该编辑锁' });
+      return;
+    }
+
+    await prisma.editLock.delete({ where: { id: lock.id } });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Release edit lock error:', error);
+    res.status(500).json({ error: '释放编辑锁失败' });
+  }
+});
+
+app.delete('/api/admin/locks/:collection/:recordId', requireAdmin, async (req, res) => {
+  try {
+    const collection = normalizeEditLockCollection(req.params.collection);
+    const recordId = normalizeEditLockRecordId(req.params.recordId);
+    if (!collection || !recordId) {
+      res.status(400).json({ error: '缺少有效的锁定目标' });
+      return;
+    }
+
+    await prisma.editLock.deleteMany({
+      where: {
+        collection,
+        recordId,
+      },
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Force release edit lock error:', error);
+    res.status(500).json({ error: '强制释放编辑锁失败' });
   }
 });
 
@@ -10289,6 +10966,23 @@ app.get('/api/admin/:tab', requireAdmin, async (req, res) => {
       return;
     }
 
+    if (tab === 'locks') {
+      await prisma.editLock.deleteMany({
+        where: {
+          expiresAt: {
+            lt: new Date(),
+          },
+        },
+      });
+
+      const data = await prisma.editLock.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 200,
+      });
+      res.json({ data: data.map(toEditLockResponse) });
+      return;
+    }
+
     res.status(400).json({ error: '未知数据类型' });
   } catch (error) {
     console.error('Fetch admin data error:', error);
@@ -10403,6 +11097,16 @@ app.get('/api/admin/:tab/:id', requireAdmin, async (req, res) => {
       return;
     }
 
+    if (tab === 'locks') {
+      const item = await prisma.editLock.findUnique({ where: { id } });
+      if (!item) {
+        res.status(404).json({ error: '记录不存在' });
+        return;
+      }
+      res.json({ item: toEditLockResponse(item) });
+      return;
+    }
+
     res.status(400).json({ error: '未知数据类型' });
   } catch (error) {
     console.error('Fetch admin item error:', error);
@@ -10480,6 +11184,12 @@ app.delete('/api/admin/:tab/:id', requireAdmin, async (req: AuthenticatedRequest
     }
     if (tab === 'music') {
       await prisma.musicTrack.delete({ where: { docId: id } });
+      res.json({ success: true });
+      return;
+    }
+
+    if (tab === 'locks') {
+      await prisma.editLock.delete({ where: { id } });
       res.json({ success: true });
       return;
     }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,11 +1,42 @@
-import React, { useEffect, useState } from 'react';
-import { collection, query, getDocs, doc, deleteDoc, updateDoc, orderBy, limit, setDoc, addDoc, serverTimestamp, db } from '../firebase';
-import { useAuth } from '../context/AuthContext';
-import { Shield, Book, MessageSquare, Image as ImageIcon, Users, Trash2, CheckCircle, XCircle, AlertTriangle, ChevronRight, Layers, Plus, Save, Edit2, Megaphone, Music as MusicIcon } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  Book,
+  CheckCircle,
+  Image as ImageIcon,
+  Layers,
+  Megaphone,
+  MessageSquare,
+  Music as MusicIcon,
+  Plus,
+  Shield,
+  Trash2,
+  Users,
+  XCircle,
+  Lock,
+} from 'lucide-react';
 import { format } from 'date-fns';
 import { clsx } from 'clsx';
-import { motion, AnimatePresence } from 'motion/react';
-import { apiGet, apiPost } from '../lib/apiClient';
+import { useAuth } from '../context/AuthContext';
+import { apiDelete, apiGet, apiPatch, apiPost } from '../lib/apiClient';
+
+type AdminTab = 'reviews' | 'wiki' | 'posts' | 'galleries' | 'users' | 'sections' | 'announcements' | 'music' | 'locks';
+type ReviewFilter = 'all' | 'wiki' | 'posts';
+
+type ReviewQueueBucket = {
+  type: 'wiki' | 'posts';
+  items: any[];
+};
+
+type EditLockItem = {
+  id: string;
+  collection: string;
+  recordId: string;
+  userId: string;
+  username: string;
+  createdAt: string;
+  expiresAt: string;
+};
 
 const toDateValue = (value: string | null | undefined) => {
   if (!value) return null;
@@ -13,54 +44,55 @@ const toDateValue = (value: string | null | undefined) => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+const formatDateTime = (value: string | null | undefined, fallback = 'N/A') => {
+  const parsed = toDateValue(value);
+  return parsed ? format(parsed, 'yyyy-MM-dd HH:mm') : fallback;
+};
+
 const Admin = () => {
   const { user, profile, isAdmin } = useAuth();
-  const [activeTab, setActiveTab] = useState<'reviews' | 'wiki' | 'posts' | 'galleries' | 'users' | 'sections' | 'announcements' | 'music'>('wiki');
-  const [data, setData] = useState<any[]>([]);
+  const [activeTab, setActiveTab] = useState<AdminTab>('reviews');
   const [loading, setLoading] = useState(true);
-  const [reviewFilter, setReviewFilter] = useState<'all' | 'wiki' | 'posts'>('all');
-  const [reviewItems, setReviewItems] = useState<any[]>([]);
+  const [data, setData] = useState<any[]>([]);
+
+  const [reviewFilter, setReviewFilter] = useState<ReviewFilter>('all');
   const [reviewLoading, setReviewLoading] = useState(false);
+  const [reviewItems, setReviewItems] = useState<any[]>([]);
+
   const [newSection, setNewSection] = useState({ name: '', description: '', order: 0 });
   const [newAnnouncement, setNewAnnouncement] = useState({ content: '', link: '', active: true });
-  const [, setEditingSection] = useState<string | null>(null);
 
-  const isSuperAdmin = profile?.role === 'super_admin' || user?.email === 'yangwenjie1231@gmail.com';
+  const isSuperAdmin = profile?.role === 'super_admin';
 
-  const fetchData = async () => {
-    setLoading(true);
-    try {
-      const colRef = collection(db, activeTab);
-      let q;
-      if (activeTab === 'users') {
-        q = query(colRef, limit(100));
-      } else if (activeTab === 'sections' || activeTab === 'announcements') {
-        q = query(colRef, orderBy('createdAt', 'desc'), limit(100));
-      } else {
-        q = query(colRef, orderBy('updatedAt', 'desc'), limit(100));
-      }
-      const snapshot = await getDocs(q);
-      setData(snapshot.docs.map(doc => ({ ...(doc.data() as any), docId: doc.id })));
-    } catch (e) {
-      console.error("Error fetching admin data:", e);
-    }
-    setLoading(false);
-  };
+  const tabConfig = useMemo(
+    () => [
+      { id: 'reviews' as const, label: '审核队列', icon: CheckCircle },
+      { id: 'wiki' as const, label: '百科管理', icon: Book },
+      { id: 'music' as const, label: '音乐管理', icon: MusicIcon },
+      { id: 'posts' as const, label: '帖子管理', icon: MessageSquare },
+      { id: 'sections' as const, label: '版块管理', icon: Layers },
+      { id: 'announcements' as const, label: '公告管理', icon: Megaphone },
+      { id: 'galleries' as const, label: '图集管理', icon: ImageIcon },
+      { id: 'users' as const, label: '用户管理', icon: Users },
+      { id: 'locks' as const, label: '编辑锁', icon: Lock },
+    ],
+    [],
+  );
 
   const fetchReviewQueue = async () => {
     setReviewLoading(true);
     try {
-      const requests: Promise<any>[] = [];
+      const requests: Promise<ReviewQueueBucket>[] = [];
       if (reviewFilter === 'all' || reviewFilter === 'wiki') {
-        requests.push(apiGet<{ type: 'wiki'; items: any[] }>('/api/admin/review-queue', { type: 'wiki', status: 'pending' }));
+        requests.push(apiGet<ReviewQueueBucket>('/api/admin/review-queue', { type: 'wiki', status: 'pending' }));
       }
       if (reviewFilter === 'all' || reviewFilter === 'posts') {
-        requests.push(apiGet<{ type: 'posts'; items: any[] }>('/api/admin/review-queue', { type: 'posts', status: 'pending' }));
+        requests.push(apiGet<ReviewQueueBucket>('/api/admin/review-queue', { type: 'posts', status: 'pending' }));
       }
 
       const result = await Promise.all(requests);
       const merged = result.flatMap((bucket) =>
-        (bucket.items || []).map((item: any) => ({
+        (bucket.items || []).map((item) => ({
           ...item,
           reviewType: bucket.type,
           reviewId: bucket.type === 'wiki' ? item.slug : item.id,
@@ -68,8 +100,8 @@ const Admin = () => {
       );
 
       merged.sort((a, b) => {
-        const left = new Date(a.updatedAt || 0).getTime();
-        const right = new Date(b.updatedAt || 0).getTime();
+        const left = toDateValue(a.updatedAt)?.getTime() || 0;
+        const right = toDateValue(b.updatedAt)?.getTime() || 0;
         return right - left;
       });
 
@@ -78,6 +110,24 @@ const Admin = () => {
       console.error('Error fetching review queue:', error);
     } finally {
       setReviewLoading(false);
+    }
+  };
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      if (activeTab === 'locks') {
+        const result = await apiGet<{ locks: EditLockItem[] }>('/api/admin/locks');
+        setData(result.locks || []);
+      } else {
+        const result = await apiGet<{ data: any[] }>(`/api/admin/${activeTab}`);
+        setData(result.data || []);
+      }
+    } catch (error) {
+      console.error('Error fetching admin data:', error);
+      setData([]);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -90,15 +140,29 @@ const Admin = () => {
   }, [activeTab, reviewFilter]);
 
   const handleReviewAction = async (item: any, action: 'approve' | 'reject') => {
-    const note = window.prompt(action === 'approve' ? '通过备注（可选）' : '驳回原因（可选）', action === 'reject' ? '请按规范完善内容' : '') || '';
+    const note =
+      window.prompt(action === 'approve' ? '通过备注（可选）' : '驳回原因（可选）', action === 'reject' ? '请按规范完善内容' : '') || '';
     try {
-      await apiPost(`/api/admin/review/${item.reviewType}/${item.reviewId}/${action}`, {
-        note,
-      });
+      await apiPost(`/api/admin/review/${item.reviewType}/${item.reviewId}/${action}`, { note });
       await fetchReviewQueue();
     } catch (error) {
       console.error(`${action} review item error:`, error);
       alert(action === 'approve' ? '审核通过失败' : '驳回失败');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('确定要删除这项内容吗？此操作不可撤销。')) return;
+    try {
+      if (activeTab === 'locks') {
+        await apiDelete(`/api/admin/locks/${id}`);
+      } else {
+        await apiDelete(`/api/admin/${activeTab}/${id}`);
+      }
+      setData((prev) => prev.filter((item) => (item.docId || item.id || item.uid) !== id));
+    } catch (error) {
+      console.error('Delete error:', error);
+      alert('删除失败');
     }
   };
 
@@ -118,74 +182,81 @@ const Admin = () => {
 
     try {
       const endpoint = shouldUnban ? `/api/admin/users/${targetUser.uid}/unban` : `/api/admin/users/${targetUser.uid}/ban`;
-      const data = await apiPost<{ user: any }>(endpoint, shouldUnban ? { note } : { reason: note, note });
-      setData((prev) => prev.map((item) => (item.uid === targetUser.uid ? { ...item, ...data.user } : item)));
+      const result = await apiPost<{ user: any }>(endpoint, shouldUnban ? { note } : { reason: note, note });
+      setData((prev) => prev.map((item) => (item.uid === targetUser.uid ? { ...item, ...result.user } : item)));
     } catch (error) {
       console.error('Toggle user ban error:', error);
       alert(shouldUnban ? '解封失败' : '封禁失败');
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm("确定要删除这项内容吗？此操作不可撤销。")) return;
-    try {
-      await deleteDoc(doc(db, activeTab, id));
-      setData(prev => prev.filter(item => item.docId !== id && item.uid !== id));
-    } catch (e) {
-      console.error("Delete error:", e);
-      alert("删除失败");
-    }
-  };
-
-  const toggleAdmin = async (targetUser: any) => {
+  const toggleAdminRole = async (targetUser: any) => {
     if (!isSuperAdmin) {
-      alert("只有超级管理员可以更改权限");
+      alert('只有超级管理员可以更改权限');
       return;
     }
     const newRole = targetUser.role === 'admin' ? 'user' : 'admin';
-    if (!window.confirm(`确定要将 ${targetUser.displayName} 的角色更改为 ${newRole} 吗？`)) return;
+    if (!window.confirm(`确定要将 ${targetUser.displayName || targetUser.uid} 的角色更改为 ${newRole} 吗？`)) return;
     try {
-      await updateDoc(doc(db, 'users', targetUser.uid), { role: newRole });
-      setData(prev => prev.map(u => u.uid === targetUser.uid ? { ...u, role: newRole } : u));
-    } catch (e) {
-      console.error("Update role error:", e);
-      alert("更新角色失败");
+      await apiPatch(`/api/users/${targetUser.uid}/role`, { role: newRole });
+      setData((prev) => prev.map((item) => (item.uid === targetUser.uid ? { ...item, role: newRole } : item)));
+    } catch (error) {
+      console.error('Update role error:', error);
+      alert('更新角色失败');
     }
   };
 
   const handleAddSection = async () => {
-    if (!newSection.name) return;
+    if (!newSection.name.trim()) return;
     try {
-      const id = newSection.name.toLowerCase().replace(/\s+/g, '-');
-      await setDoc(doc(db, 'sections', id), { ...newSection, id, createdAt: serverTimestamp() });
+      await apiPost('/api/sections', {
+        name: newSection.name.trim(),
+        description: newSection.description.trim(),
+        order: Number.isFinite(newSection.order) ? newSection.order : 0,
+      });
       setNewSection({ name: '', description: '', order: 0 });
-      fetchData();
-    } catch (e) {
-      console.error("Add section error:", e);
+      await fetchData();
+    } catch (error) {
+      console.error('Add section error:', error);
+      alert('新增版块失败');
     }
   };
 
   const handleAddAnnouncement = async () => {
-    if (!newAnnouncement.content) return;
+    if (!newAnnouncement.content.trim()) return;
     try {
-      await addDoc(collection(db, 'announcements'), {
-        ...newAnnouncement,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp()
+      await apiPost('/api/announcements', {
+        content: newAnnouncement.content.trim(),
+        link: newAnnouncement.link.trim() || null,
+        active: newAnnouncement.active,
       });
       setNewAnnouncement({ content: '', link: '', active: true });
-      fetchData();
-    } catch (e) {
-      console.error("Add announcement error:", e);
+      await fetchData();
+    } catch (error) {
+      console.error('Add announcement error:', error);
+      alert('新增公告失败');
     }
   };
 
   const toggleAnnouncement = async (ann: any) => {
     try {
-      await updateDoc(doc(db, 'announcements', ann.id), { active: !ann.active });
-      setData(prev => prev.map(a => a.id === ann.id ? { ...a, active: !ann.active } : a));
-    } catch (e) {
-      console.error("Toggle announcement error:", e);
+      const result = await apiPatch<{ announcement: any }>(`/api/announcements/${ann.id}`, { active: !ann.active });
+      const updated = result.announcement;
+      setData((prev) => prev.map((item) => (item.id === ann.id ? { ...item, active: updated?.active ?? !ann.active } : item)));
+    } catch (error) {
+      console.error('Toggle announcement error:', error);
+      alert('更新公告状态失败');
+    }
+  };
+
+  const forceReleaseLock = async (lock: EditLockItem) => {
+    if (!window.confirm('确定要强制释放这个编辑锁吗？')) return;
+    try {
+      await apiDelete(`/api/admin/locks/${lock.collection}/${encodeURIComponent(lock.recordId)}`);
+      setData((prev) => prev.filter((item) => item.id !== lock.id));
+    } catch (error) {
+      console.error('Force release lock error:', error);
+      alert('强制释放失败');
     }
   };
 
@@ -214,63 +285,51 @@ const Admin = () => {
       </header>
 
       <div className="flex flex-wrap gap-4 mb-8">
-        {[
-          { id: 'reviews', label: '审核队列', icon: CheckCircle },
-          { id: 'wiki', label: '百科管理', icon: Book },
-          { id: 'music', label: '音乐管理', icon: MusicIcon },
-          { id: 'posts', label: '帖子管理', icon: MessageSquare },
-          { id: 'sections', label: '版块管理', icon: Layers },
-          { id: 'announcements', label: '公告管理', icon: Megaphone },
-          { id: 'galleries', label: '图集管理', icon: ImageIcon },
-          { id: 'users', label: '用户管理', icon: Users },
-        ].map(tab => (
+        {tabConfig.map((tab) => (
           <button
             key={tab.id}
-            onClick={() => setActiveTab(tab.id as any)}
+            onClick={() => setActiveTab(tab.id)}
             className={clsx(
-              "px-8 py-4 rounded-3xl font-bold transition-all flex items-center gap-3 shadow-sm border",
-              activeTab === tab.id 
-                ? "bg-brand-primary text-gray-900 border-brand-primary" 
-                : "bg-white text-gray-500 border-gray-100 hover:border-brand-primary/20"
+              'px-6 py-3 rounded-3xl font-bold transition-all flex items-center gap-3 shadow-sm border',
+              activeTab === tab.id
+                ? 'bg-brand-primary text-gray-900 border-brand-primary'
+                : 'bg-white text-gray-500 border-gray-100 hover:border-brand-primary/20',
             )}
           >
-            <tab.icon size={20} />
+            <tab.icon size={18} />
             {tab.label}
           </button>
         ))}
       </div>
 
       {activeTab === 'sections' && (
-        <div className="mb-8 p-8 bg-brand-cream/30 rounded-[32px] border border-brand-primary/10">
-          <h3 className="text-xl font-serif font-bold text-gray-900 mb-6 flex items-center gap-2">
-            <Plus size={20} /> 新增论坛版块
+        <div className="mb-8 p-6 bg-brand-cream/30 rounded-[28px] border border-brand-primary/10">
+          <h3 className="text-xl font-serif font-bold text-gray-900 mb-4 flex items-center gap-2">
+            <Plus size={18} /> 新增论坛版块
           </h3>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <input 
-              type="text" 
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <input
+              type="text"
               placeholder="版块名称"
               value={newSection.name}
-              onChange={e => setNewSection({...newSection, name: e.target.value})}
+              onChange={(event) => setNewSection((prev) => ({ ...prev, name: event.target.value }))}
               className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20"
             />
-            <input 
-              type="text" 
+            <input
+              type="text"
               placeholder="描述"
               value={newSection.description}
-              onChange={e => setNewSection({...newSection, description: e.target.value})}
+              onChange={(event) => setNewSection((prev) => ({ ...prev, description: event.target.value }))}
               className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20"
             />
-            <input 
-              type="number" 
+            <input
+              type="number"
               placeholder="排序"
               value={newSection.order}
-              onChange={e => setNewSection({...newSection, order: parseInt(e.target.value)})}
+              onChange={(event) => setNewSection((prev) => ({ ...prev, order: Number(event.target.value || 0) }))}
               className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20"
             />
-            <button 
-              onClick={handleAddSection}
-              className="px-6 py-2 bg-brand-primary text-gray-900 rounded-xl font-bold hover:scale-105 transition-all"
-            >
+            <button onClick={handleAddSection} className="px-6 py-2 bg-brand-primary text-gray-900 rounded-xl font-bold">
               添加版块
             </button>
           </div>
@@ -278,36 +337,33 @@ const Admin = () => {
       )}
 
       {activeTab === 'announcements' && (
-        <div className="mb-8 p-8 bg-brand-cream/30 rounded-[32px] border border-brand-primary/10">
-          <h3 className="text-xl font-serif font-bold text-gray-900 mb-6 flex items-center gap-2">
-            <Plus size={20} /> 新增公告
+        <div className="mb-8 p-6 bg-brand-cream/30 rounded-[28px] border border-brand-primary/10">
+          <h3 className="text-xl font-serif font-bold text-gray-900 mb-4 flex items-center gap-2">
+            <Plus size={18} /> 新增公告
           </h3>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <input 
-              type="text" 
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <input
+              type="text"
               placeholder="公告内容"
               value={newAnnouncement.content}
-              onChange={e => setNewAnnouncement({...newAnnouncement, content: e.target.value})}
-              className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20 col-span-2"
+              onChange={(event) => setNewAnnouncement((prev) => ({ ...prev, content: event.target.value }))}
+              className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20 md:col-span-2"
             />
-            <input 
-              type="text" 
+            <input
+              type="text"
               placeholder="跳转链接 (可选)"
               value={newAnnouncement.link}
-              onChange={e => setNewAnnouncement({...newAnnouncement, link: e.target.value})}
+              onChange={(event) => setNewAnnouncement((prev) => ({ ...prev, link: event.target.value }))}
               className="px-4 py-2 bg-white rounded-xl border-none focus:ring-2 focus:ring-brand-primary/20"
             />
-            <button 
-              onClick={handleAddAnnouncement}
-              className="px-6 py-2 bg-brand-primary text-gray-900 rounded-xl font-bold hover:scale-105 transition-all"
-            >
+            <button onClick={handleAddAnnouncement} className="px-6 py-2 bg-brand-primary text-gray-900 rounded-xl font-bold">
               发布公告
             </button>
           </div>
         </div>
       )}
 
-      {activeTab === 'reviews' && (
+      {activeTab === 'reviews' ? (
         <div className="space-y-6">
           <div className="bg-white rounded-[28px] border border-gray-100 p-4 sm:p-6 flex flex-wrap items-center justify-between gap-4">
             <div className="flex items-center gap-3">
@@ -318,12 +374,10 @@ const Admin = () => {
               ].map((item) => (
                 <button
                   key={item.id}
-                  onClick={() => setReviewFilter(item.id as 'all' | 'wiki' | 'posts')}
+                  onClick={() => setReviewFilter(item.id as ReviewFilter)}
                   className={clsx(
                     'px-4 py-2 rounded-full text-xs font-bold transition-all',
-                    reviewFilter === item.id
-                      ? 'bg-brand-primary text-gray-900'
-                      : 'bg-gray-50 text-gray-500 hover:bg-gray-100',
+                    reviewFilter === item.id ? 'bg-brand-primary text-gray-900' : 'bg-gray-50 text-gray-500 hover:bg-gray-100',
                   )}
                 >
                   {item.label}
@@ -351,24 +405,19 @@ const Admin = () => {
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="min-w-0">
                       <div className="flex items-center gap-2 mb-2">
-                        <span className={clsx(
-                          'px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider',
-                          item.reviewType === 'wiki' ? 'bg-brand-cream text-brand-olive' : 'bg-brand-primary/10 text-brand-primary',
-                        )}
+                        <span
+                          className={clsx(
+                            'px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider',
+                            item.reviewType === 'wiki' ? 'bg-brand-cream text-brand-olive' : 'bg-brand-primary/10 text-brand-primary',
+                          )}
                         >
                           {item.reviewType === 'wiki' ? '百科' : '帖子'}
                         </span>
-                        <span className="px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider bg-amber-100 text-amber-700">
-                          待审核
-                        </span>
+                        <span className="px-2 py-1 rounded text-[10px] font-bold uppercase tracking-wider bg-amber-100 text-amber-700">待审核</span>
                       </div>
                       <p className="font-bold text-gray-800 mb-1">{item.title || item.slug || item.id}</p>
-                      <p className="text-xs text-gray-500 line-clamp-2">
-                        {(item.content || '').replace(/[#*`]/g, '').slice(0, 160) || '无内容摘要'}
-                      </p>
-                      <p className="text-[10px] text-gray-400 mt-2">
-                        更新时间：{toDateValue(item.updatedAt) ? format(toDateValue(item.updatedAt)!, 'yyyy-MM-dd HH:mm') : 'N/A'}
-                      </p>
+                      <p className="text-xs text-gray-500 line-clamp-2">{(item.content || '').replace(/[#*`]/g, '').slice(0, 160) || '无内容摘要'}</p>
+                      <p className="text-[10px] text-gray-400 mt-2">更新时间：{formatDateTime(item.updatedAt)}</p>
                     </div>
                     <div className="flex items-center gap-2">
                       <button
@@ -389,132 +438,191 @@ const Admin = () => {
               ))}
             </div>
           ) : (
-            <div className="bg-white rounded-3xl border border-gray-100 py-16 text-center text-gray-400 italic">
-              当前没有待审核内容
-            </div>
+            <div className="bg-white rounded-3xl border border-gray-100 py-16 text-center text-gray-400 italic">当前没有待审核内容</div>
           )}
         </div>
-      )}
+      ) : (
+        <div className="bg-white rounded-[36px] border border-gray-100 shadow-sm overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="bg-brand-cream/50 border-b border-gray-100">
+                  <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-brand-olive/60">内容详情</th>
+                  <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-brand-olive/60">状态/分类</th>
+                  <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-brand-olive/60">最后更新</th>
+                  <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-brand-olive/60 text-right">操作</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {loading ? (
+                  [1, 2, 3, 4, 5].map((i) => (
+                    <tr key={i} className="animate-pulse">
+                      <td colSpan={4} className="px-6 py-4">
+                        <div className="h-8 bg-gray-50 rounded-xl" />
+                      </td>
+                    </tr>
+                  ))
+                ) : data.length > 0 ? (
+                  data.map((item) => {
+                    const rowId = item.docId || item.id || item.uid;
+                    return (
+                      <tr key={rowId} className="hover:bg-gray-50/50 transition-colors group">
+                        <td className="px-6 py-4">
+                          <div className="flex items-center gap-3">
+                            {activeTab === 'users' ? (
+                              <img src={item.photoURL || ''} alt="" className="w-10 h-10 rounded-full object-cover bg-gray-100" referrerPolicy="no-referrer" />
+                            ) : activeTab === 'galleries' ? (
+                              <img
+                                src={item.images?.[0]?.url || ''}
+                                alt=""
+                                className="w-12 h-12 rounded-xl object-cover bg-gray-100"
+                                referrerPolicy="no-referrer"
+                              />
+                            ) : activeTab === 'music' ? (
+                              <img src={item.cover || ''} alt="" className="w-12 h-12 rounded-xl object-cover bg-gray-100" referrerPolicy="no-referrer" />
+                            ) : (
+                              <div className="w-10 h-10 rounded-full bg-brand-cream flex items-center justify-center text-brand-olive">
+                                {activeTab === 'wiki' ? <Book size={18} /> : activeTab === 'locks' ? <Lock size={18} /> : <MessageSquare size={18} />}
+                              </div>
+                            )}
+                            <div>
+                              {activeTab === 'locks' ? (
+                                <>
+                                  <p className="font-bold text-gray-700">{item.collection} / {item.recordId}</p>
+                                  <p className="text-xs text-gray-400">{item.username} ({item.userId.slice(0, 8)})</p>
+                                </>
+                              ) : (
+                                <>
+                                  <p className="font-bold text-gray-700">{item.title || item.displayName || item.slug || item.id}</p>
+                                  <p className="text-xs text-gray-400 truncate max-w-xs">
+                                    {item.content?.slice(0, 60) || item.email || item.description || item.artist || ''}
+                                  </p>
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4">
+                          <div className="flex flex-wrap gap-2">
+                            {activeTab === 'users' ? (
+                              <>
+                                <span
+                                  className={clsx(
+                                    'px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider',
+                                    item.role === 'super_admin'
+                                      ? 'bg-purple-100 text-purple-600'
+                                      : item.role === 'admin'
+                                        ? 'bg-red-100 text-red-600'
+                                        : 'bg-brand-cream text-brand-olive',
+                                  )}
+                                >
+                                  {item.role === 'super_admin' ? '超级管理员' : item.role || 'user'}
+                                </span>
+                                <span
+                                  className={clsx(
+                                    'px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider',
+                                    item.status === 'banned' ? 'bg-red-100 text-red-600' : 'bg-green-100 text-green-700',
+                                  )}
+                                >
+                                  {item.status === 'banned' ? '已封禁' : '正常'}
+                                </span>
+                              </>
+                            ) : activeTab === 'announcements' ? (
+                              <span
+                                className={clsx(
+                                  'px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider',
+                                  item.active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600',
+                                )}
+                              >
+                                {item.active ? '启用中' : '已禁用'}
+                              </span>
+                            ) : activeTab === 'locks' ? (
+                              <span className="px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider bg-amber-100 text-amber-700">
+                                到期: {formatDateTime(item.expiresAt)}
+                              </span>
+                            ) : (
+                              <span className="px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider bg-brand-cream text-brand-olive">
+                                {item.category || item.section || item.name || item.status || '默认'}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 text-xs text-gray-400">
+                          {activeTab === 'locks'
+                            ? formatDateTime(item.createdAt)
+                            : formatDateTime(item.updatedAt, item.order !== undefined ? `排序: ${item.order}` : 'N/A')}
+                        </td>
+                        <td className="px-6 py-4 text-right">
+                          <div className="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                            {activeTab === 'announcements' && (
+                              <button
+                                onClick={() => toggleAnnouncement(item)}
+                                className={clsx(
+                                  'p-2 rounded-lg transition-all',
+                                  item.active ? 'text-green-500 hover:bg-green-50' : 'text-gray-400 hover:bg-gray-50',
+                                )}
+                                title={item.active ? '禁用公告' : '启用公告'}
+                              >
+                                {item.active ? <CheckCircle size={18} /> : <XCircle size={18} />}
+                              </button>
+                            )}
 
-      {activeTab !== 'reviews' && (
-      <div className="bg-white rounded-[40px] border border-gray-100 shadow-sm overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="w-full text-left border-collapse">
-            <thead>
-              <tr className="bg-brand-cream/50 border-b border-gray-100">
-                <th className="px-8 py-6 text-xs font-bold uppercase tracking-widest text-brand-olive/60">内容详情</th>
-                <th className="px-8 py-6 text-xs font-bold uppercase tracking-widest text-brand-olive/60">状态/分类</th>
-                <th className="px-8 py-6 text-xs font-bold uppercase tracking-widest text-brand-olive/60">最后更新</th>
-                <th className="px-8 py-6 text-xs font-bold uppercase tracking-widest text-brand-olive/60 text-right">操作</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-50">
-              {loading ? (
-                [1, 2, 3, 4, 5].map(i => (
-                  <tr key={i} className="animate-pulse">
-                    <td colSpan={4} className="px-8 py-6"><div className="h-8 bg-gray-50 rounded-xl"></div></td>
+                            {activeTab === 'users' && isSuperAdmin && item.uid !== user?.uid && (
+                              <button
+                                onClick={() => toggleAdminRole(item)}
+                                className="p-2 text-brand-olive hover:bg-brand-cream rounded-lg transition-all"
+                                title={item.role === 'admin' ? '取消管理员' : '设为管理员'}
+                              >
+                                {item.role === 'admin' ? <XCircle size={18} /> : <CheckCircle size={18} />}
+                              </button>
+                            )}
+
+                            {activeTab === 'users' && item.uid !== user?.uid && (
+                              <button
+                                onClick={() => toggleUserBan(item)}
+                                className={clsx(
+                                  'p-2 rounded-lg transition-all',
+                                  item.status === 'banned' ? 'text-green-600 hover:bg-green-50' : 'text-amber-600 hover:bg-amber-50',
+                                )}
+                                title={item.status === 'banned' ? '解封用户' : '封禁用户'}
+                              >
+                                {item.status === 'banned' ? <CheckCircle size={18} /> : <AlertTriangle size={18} />}
+                              </button>
+                            )}
+
+                            {activeTab === 'locks' && (
+                              <button
+                                onClick={() => forceReleaseLock(item as EditLockItem)}
+                                className="p-2 text-amber-600 hover:bg-amber-50 rounded-lg transition-all"
+                                title="强制释放"
+                              >
+                                <Lock size={18} />
+                              </button>
+                            )}
+
+                            <button
+                              onClick={() => handleDelete(rowId)}
+                              className="p-2 text-red-400 hover:bg-red-50 rounded-lg transition-all"
+                              title="删除"
+                            >
+                              <Trash2 size={18} />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-6 py-16 text-center text-gray-400 italic">
+                      暂无数据
+                    </td>
                   </tr>
-                ))
-              ) : data.length > 0 ? data.map((item) => (
-                <tr key={item.docId || item.uid} className="hover:bg-gray-50/50 transition-colors group">
-                  <td className="px-8 py-6">
-                    <div className="flex items-center gap-4">
-                      {activeTab === 'users' ? (
-                        <img src={item.photoURL} alt="" className="w-10 h-10 rounded-full object-cover" referrerPolicy="no-referrer" />
-                      ) : activeTab === 'galleries' ? (
-                        <img src={item.images?.[0]?.url} alt="" className="w-12 h-12 rounded-xl object-cover" referrerPolicy="no-referrer" />
-                      ) : activeTab === 'music' ? (
-                        <img src={item.cover} alt="" className="w-12 h-12 rounded-xl object-cover" referrerPolicy="no-referrer" />
-                      ) : (
-                        <div className="w-10 h-10 rounded-full bg-brand-cream flex items-center justify-center text-brand-olive">
-                          {activeTab === 'wiki' ? <Book size={20} /> : <MessageSquare size={20} />}
-                        </div>
-                      )}
-                      <div>
-                        <p className="font-bold text-gray-700">{item.title || item.displayName || item.slug}</p>
-                        <p className="text-xs text-gray-400 truncate max-w-xs">{item.content?.substring(0, 50) || item.email || item.description || item.artist}</p>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-8 py-6">
-                    <div className="flex flex-wrap gap-2">
-                      <span className={clsx(
-                        "px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider",
-                        item.role === 'super_admin' ? "bg-purple-100 text-purple-600" :
-                        item.role === 'admin' ? "bg-red-100 text-red-600" : "bg-brand-cream text-brand-olive"
-                      )}>
-                        {item.role === 'super_admin' ? '超级管理员' : item.category || item.section || item.role || item.name || '默认'}
-                      </span>
-                      {activeTab === 'users' && (
-                        <span className={clsx(
-                          'px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider',
-                          item.status === 'banned' ? 'bg-red-100 text-red-600' : 'bg-green-100 text-green-700',
-                        )}>
-                          {item.status === 'banned' ? '已封禁' : '正常'}
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-8 py-6 text-xs text-gray-400">
-                    {toDateValue(item.updatedAt) ? format(toDateValue(item.updatedAt)!, 'yyyy-MM-dd HH:mm') : 
-                     item.order !== undefined ? `排序: ${item.order}` : 'N/A'}
-                  </td>
-                  <td className="px-8 py-6 text-right">
-                    <div className="flex items-center justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                      {activeTab === 'announcements' && (
-                        <button 
-                          onClick={() => toggleAnnouncement(item)}
-                          className={clsx(
-                            "p-2 rounded-lg transition-all",
-                            item.active ? "text-green-500 hover:bg-green-50" : "text-gray-400 hover:bg-gray-50"
-                          )}
-                          title={item.active ? "禁用公告" : "启用公告"}
-                        >
-                          {item.active ? <CheckCircle size={18} /> : <XCircle size={18} />}
-                        </button>
-                      )}
-                      {activeTab === 'users' && isSuperAdmin && (
-                        <button 
-                          onClick={() => toggleAdmin(item)}
-                          className="p-2 text-brand-olive hover:bg-brand-cream rounded-lg transition-all"
-                          title={item.role === 'admin' ? "取消管理员" : "设为管理员"}
-                        >
-                          {item.role === 'admin' ? <XCircle size={18} /> : <CheckCircle size={18} />}
-                        </button>
-                      )}
-                      {activeTab === 'users' && item.uid !== user?.uid && (
-                        <button
-                          onClick={() => toggleUserBan(item)}
-                          className={clsx(
-                            'p-2 rounded-lg transition-all',
-                            item.status === 'banned'
-                              ? 'text-green-600 hover:bg-green-50'
-                              : 'text-amber-600 hover:bg-amber-50',
-                          )}
-                          title={item.status === 'banned' ? '解封用户' : '封禁用户'}
-                        >
-                          {item.status === 'banned' ? <CheckCircle size={18} /> : <AlertTriangle size={18} />}
-                        </button>
-                      )}
-                      <button 
-                        onClick={() => handleDelete(item.docId || item.uid)}
-                        className="p-2 text-red-400 hover:bg-red-50 rounded-lg transition-all"
-                        title="删除"
-                      >
-                        <Trash2 size={18} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              )) : (
-                <tr>
-                  <td colSpan={4} className="px-8 py-20 text-center text-gray-400 italic">暂无数据</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+                )}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
       )}
     </div>
   );

--- a/src/pages/GalleryDetail.tsx
+++ b/src/pages/GalleryDetail.tsx
@@ -1,15 +1,34 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { ArrowLeft, Clock, User as UserIcon, ChevronLeft, ChevronRight, Link2 } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import {
+  ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Eye,
+  EyeOff,
+  GripVertical,
+  Link2,
+  Plus,
+  Save,
+  Trash2,
+  User as UserIcon,
+} from 'lucide-react';
 import { format } from 'date-fns';
+import { clsx } from 'clsx';
+import { useAuth } from '../context/AuthContext';
 import { SmartImage } from '../components/SmartImage';
-import { apiGet } from '../lib/apiClient';
 import { useToast } from '../components/Toast';
 import { copyToClipboard, toAbsoluteInternalUrl } from '../lib/copyLink';
+import { apiDelete, apiGet, apiPatch, apiPost } from '../lib/apiClient';
 
 type GalleryImage = {
+  id: string;
+  assetId: string | null;
   url: string;
   name: string;
+  mimeType: string | null;
+  sizeBytes: number | null;
 };
 
 type GalleryItem = {
@@ -19,9 +38,23 @@ type GalleryItem = {
   authorUid: string;
   authorName: string;
   tags: string[];
+  published: boolean;
+  publishedAt: string | null;
   createdAt: string;
   updatedAt: string;
   images: GalleryImage[];
+};
+
+type UploadSessionResponse = {
+  session: {
+    id: string;
+  };
+};
+
+type UploadFileResponse = {
+  asset: {
+    id: string;
+  };
 };
 
 const toDateValue = (value: string | null | undefined) => {
@@ -30,33 +63,65 @@ const toDateValue = (value: string | null | undefined) => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+const formatDateTime = (value: string | null | undefined, fallback = '刚刚') => {
+  const parsed = toDateValue(value);
+  return parsed ? format(parsed, 'yyyy-MM-dd HH:mm') : fallback;
+};
+
+const splitTagsInput = (value: string) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
 const GalleryDetail = () => {
   const { galleryId } = useParams();
+  const navigate = useNavigate();
+  const { user, profile, isBanned } = useAuth();
+  const { show } = useToast();
+
   const [gallery, setGallery] = useState<GalleryItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [activeIndex, setActiveIndex] = useState(0);
-  const { show } = useToast();
+
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editTagsText, setEditTagsText] = useState('');
+
+  const addImagesInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchGallery = async () => {
+    if (!galleryId) return;
+    try {
+      setLoading(true);
+      const data = await apiGet<{ gallery: GalleryItem }>(`/api/galleries/${galleryId}`);
+      setGallery(data.gallery);
+      setActiveIndex(0);
+      setEditTitle(data.gallery.title || '');
+      setEditDescription(data.gallery.description || '');
+      setEditTagsText((data.gallery.tags || []).join(', '));
+    } catch (error) {
+      console.error('Fetch gallery detail error:', error);
+      setGallery(null);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchGallery = async () => {
-      if (!galleryId) return;
-      try {
-        setLoading(true);
-        const data = await apiGet<{ gallery: GalleryItem }>(`/api/galleries/${galleryId}`);
-        setGallery(data.gallery);
-        setActiveIndex(0);
-      } catch (error) {
-        console.error('Fetch gallery detail error:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchGallery();
   }, [galleryId]);
 
   const images = useMemo(() => gallery?.images || [], [gallery?.images]);
-  const activeImage = images[activeIndex];
+  const activeImage = images[activeIndex] || null;
+
+  const isAdmin = profile?.role === 'admin' || profile?.role === 'super_admin';
+  const canManage = Boolean(user && gallery && !isBanned && (gallery.authorUid === user.uid || isAdmin));
 
   const handlePrev = () => {
     if (!images.length) return;
@@ -76,6 +141,159 @@ const GalleryDetail = () => {
       return;
     }
     show('复制链接失败，请稍后重试', { variant: 'error' });
+  };
+
+  const handleSaveMeta = async () => {
+    if (!gallery || !canManage || saving) return;
+    try {
+      setSaving(true);
+      const result = await apiPatch<{ gallery: GalleryItem }>(`/api/galleries/${gallery.id}`, {
+        title: editTitle,
+        description: editDescription,
+        tags: splitTagsInput(editTagsText),
+      });
+      setGallery(result.gallery);
+      setEditTitle(result.gallery.title || '');
+      setEditDescription(result.gallery.description || '');
+      setEditTagsText((result.gallery.tags || []).join(', '));
+      setEditing(false);
+      show('图集信息已保存');
+    } catch (error) {
+      console.error('Save gallery meta error:', error);
+      show('保存失败，请稍后重试', { variant: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTogglePublish = async () => {
+    if (!gallery || !canManage || saving) return;
+    try {
+      setSaving(true);
+      const result = await apiPatch<{ gallery: GalleryItem }>(`/api/galleries/${gallery.id}/publish`, {
+        published: !gallery.published,
+      });
+      setGallery(result.gallery);
+      show(result.gallery.published ? '图集已发布' : '已切换为草稿');
+    } catch (error) {
+      console.error('Toggle gallery publish error:', error);
+      show('切换发布状态失败', { variant: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const uploadFileToSession = async (sessionId: string, file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(`/api/uploads/sessions/${sessionId}/files`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = typeof data === 'object' && data && 'error' in data ? String((data as Record<string, unknown>).error) : '上传失败';
+      throw new Error(message);
+    }
+    return data as UploadFileResponse;
+  };
+
+  const handleAddImages = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const fileList = event.target.files;
+    event.target.value = '';
+
+    if (!gallery || !canManage || !fileList?.length || uploading) return;
+    const files = Array.from(fileList);
+
+    try {
+      setUploading(true);
+      const sessionData = await apiPost<UploadSessionResponse>('/api/uploads/sessions', {
+        maxFiles: files.length,
+      });
+      const sessionId = sessionData.session.id;
+      const assetIds: string[] = [];
+
+      for (const file of files) {
+        const uploadResult = await uploadFileToSession(sessionId, file);
+        assetIds.push(uploadResult.asset.id);
+      }
+
+      await apiPost(`/api/uploads/sessions/${sessionId}/finalize`);
+      const result = await apiPost<{ gallery: GalleryItem }>(`/api/galleries/${gallery.id}/images`, {
+        uploadSessionId: sessionId,
+        assetIds,
+      });
+
+      setGallery(result.gallery);
+      setActiveIndex((prev) => Math.min(prev, Math.max(0, result.gallery.images.length - 1)));
+      show(`已追加 ${assetIds.length} 张图片`);
+    } catch (error) {
+      console.error('Add gallery images error:', error);
+      show('追加图片失败，请稍后重试', { variant: 'error' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDeleteImage = async (index: number) => {
+    if (!gallery || !canManage) return;
+    if (!window.confirm('确定删除这张图片吗？')) return;
+
+    const image = gallery.images[index];
+    if (!image?.id) {
+      show('无法删除该图片', { variant: 'error' });
+      return;
+    }
+
+    try {
+      const result = await apiDelete<{ gallery: GalleryItem }>(`/api/galleries/${gallery.id}/images/${image.id}`);
+      setGallery(result.gallery);
+      setActiveIndex((prev) => {
+        if (result.gallery.images.length === 0) return 0;
+        return Math.min(prev, result.gallery.images.length - 1);
+      });
+      show('图片已删除');
+    } catch (error) {
+      console.error('Delete gallery image error:', error);
+      show('删除图片失败', { variant: 'error' });
+    }
+  };
+
+  const handleReorder = async (fromIndex: number, toIndex: number) => {
+    if (!gallery || !canManage || fromIndex === toIndex) return;
+    const next = [...gallery.images];
+    const [moved] = next.splice(fromIndex, 1);
+    if (!moved) return;
+    next.splice(toIndex, 0, moved);
+
+    setGallery({ ...gallery, images: next });
+    setActiveIndex(toIndex);
+
+    try {
+      const imageIds = next.map((image) => image.id).filter((id): id is string => Boolean(id));
+      const result = await apiPatch<{ gallery: GalleryItem }>(`/api/galleries/${gallery.id}/images/reorder`, {
+        imageIds,
+      });
+      setGallery(result.gallery);
+    } catch (error) {
+      console.error('Reorder gallery images error:', error);
+      show('保存排序失败，已刷新原始顺序', { variant: 'error' });
+      await fetchGallery();
+    }
+  };
+
+  const onThumbDragStart = (index: number) => {
+    setDraggingIndex(index);
+  };
+
+  const onThumbDrop = async (targetIndex: number) => {
+    if (draggingIndex === null) return;
+    const sourceIndex = draggingIndex;
+    setDraggingIndex(null);
+    await handleReorder(sourceIndex, targetIndex);
   };
 
   if (loading) {
@@ -99,9 +317,50 @@ const GalleryDetail = () => {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-12 space-y-8">
-      <Link to="/gallery" className="inline-flex items-center gap-2 text-gray-400 hover:text-brand-olive transition-colors">
-        <ArrowLeft size={18} /> 返回图集
-      </Link>
+      <div className="flex items-center justify-between gap-3">
+        <Link to="/gallery" className="inline-flex items-center gap-2 text-gray-400 hover:text-brand-olive transition-colors">
+          <ArrowLeft size={18} /> 返回图集
+        </Link>
+        {canManage && (
+          <div className="flex flex-wrap items-center gap-2">
+            {editing ? (
+              <button
+                onClick={handleSaveMeta}
+                disabled={saving}
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-bold bg-brand-primary text-gray-900 disabled:opacity-50"
+              >
+                <Save size={14} /> {saving ? '保存中...' : '保存信息'}
+              </button>
+            ) : (
+              <button
+                onClick={() => setEditing(true)}
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-bold border border-gray-200 text-gray-600 hover:text-brand-olive hover:border-brand-olive/40"
+              >
+                <Save size={14} /> 编辑信息
+              </button>
+            )}
+            <button
+              onClick={handleTogglePublish}
+              disabled={saving}
+              className={clsx(
+                'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-bold disabled:opacity-50',
+                gallery.published ? 'bg-amber-50 text-amber-700' : 'bg-green-50 text-green-700',
+              )}
+            >
+              {gallery.published ? <EyeOff size={14} /> : <Eye size={14} />}
+              {saving ? '处理中...' : gallery.published ? '切换草稿' : '发布图集'}
+            </button>
+            <button
+              onClick={() => addImagesInputRef.current?.click()}
+              disabled={uploading}
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-bold bg-brand-olive text-white disabled:opacity-50"
+            >
+              <Plus size={14} /> {uploading ? '上传中...' : '追加图片'}
+            </button>
+            <input ref={addImagesInputRef} type="file" multiple accept="image/*" className="hidden" onChange={handleAddImages} />
+          </div>
+        )}
+      </div>
 
       <section className="bg-white rounded-[40px] border border-gray-100 shadow-sm overflow-hidden">
         <div className="relative bg-black/5">
@@ -114,16 +373,10 @@ const GalleryDetail = () => {
           </div>
           {images.length > 1 && (
             <>
-              <button
-                onClick={handlePrev}
-                className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/90 text-gray-700 hover:bg-white"
-              >
+              <button onClick={handlePrev} className="absolute left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/90 text-gray-700 hover:bg-white">
                 <ChevronLeft size={20} />
               </button>
-              <button
-                onClick={handleNext}
-                className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/90 text-gray-700 hover:bg-white"
-              >
+              <button onClick={handleNext} className="absolute right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white/90 text-gray-700 hover:bg-white">
                 <ChevronRight size={20} />
               </button>
             </>
@@ -132,10 +385,39 @@ const GalleryDetail = () => {
 
         <div className="p-8 sm:p-10">
           <div className="flex flex-wrap items-start justify-between gap-4 mb-4">
-            <div>
-              <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900 mb-2">{gallery.title}</h1>
-              <p className="text-gray-500 leading-relaxed">{gallery.description || '暂无描述'}</p>
+            <div className="min-w-0 flex-1">
+              {editing ? (
+                <div className="space-y-3 max-w-2xl">
+                  <input
+                    type="text"
+                    value={editTitle}
+                    onChange={(event) => setEditTitle(event.target.value)}
+                    className="w-full px-4 py-2 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-brand-olive/20"
+                    placeholder="图集标题"
+                  />
+                  <textarea
+                    value={editDescription}
+                    onChange={(event) => setEditDescription(event.target.value)}
+                    className="w-full px-4 py-2 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-brand-olive/20 resize-none"
+                    rows={3}
+                    placeholder="图集描述"
+                  />
+                  <input
+                    type="text"
+                    value={editTagsText}
+                    onChange={(event) => setEditTagsText(event.target.value)}
+                    className="w-full px-4 py-2 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-brand-olive/20"
+                    placeholder="标签，逗号分隔"
+                  />
+                </div>
+              ) : (
+                <>
+                  <h1 className="text-3xl sm:text-4xl font-serif font-bold text-gray-900 mb-2">{gallery.title}</h1>
+                  <p className="text-gray-500 leading-relaxed">{gallery.description || '暂无描述'}</p>
+                </>
+              )}
             </div>
+
             <div className="flex items-center gap-2">
               <span className="px-3 py-1 bg-black/5 text-gray-600 text-xs rounded-full font-bold">
                 {activeIndex + 1} / {images.length}
@@ -153,15 +435,32 @@ const GalleryDetail = () => {
 
           <div className="flex flex-wrap gap-2 mb-4">
             {gallery.tags?.map((tag) => (
-              <span key={tag} className="text-[11px] text-brand-olive bg-brand-cream px-2.5 py-1 rounded-full">#{tag}</span>
+              <span key={tag} className="text-[11px] text-brand-olive bg-brand-cream px-2.5 py-1 rounded-full">
+                #{tag}
+              </span>
             ))}
+            <span
+              className={clsx(
+                'text-[11px] px-2.5 py-1 rounded-full font-bold',
+                gallery.published ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700',
+              )}
+            >
+              {gallery.published ? '已发布' : '草稿'}
+            </span>
           </div>
 
           <div className="flex flex-wrap items-center gap-6 text-xs text-gray-400">
-            <span className="flex items-center gap-1"><Clock size={12} />
-              {toDateValue(gallery.createdAt) ? format(toDateValue(gallery.createdAt)!, 'yyyy-MM-dd HH:mm') : '刚刚'}
+            <span className="flex items-center gap-1">
+              <Clock size={12} /> {formatDateTime(gallery.createdAt)}
             </span>
-            <span className="flex items-center gap-1"><UserIcon size={12} /> {gallery.authorName || gallery.authorUid?.substring(0, 8)}</span>
+            <span className="flex items-center gap-1">
+              <UserIcon size={12} /> {gallery.authorName || gallery.authorUid?.slice(0, 8)}
+            </span>
+            {gallery.publishedAt && (
+              <span className="flex items-center gap-1">
+                <Eye size={12} /> 发布于 {formatDateTime(gallery.publishedAt)}
+              </span>
+            )}
           </div>
         </div>
       </section>
@@ -170,21 +469,50 @@ const GalleryDetail = () => {
         <section className="bg-white rounded-[32px] border border-gray-100 p-4 sm:p-6">
           <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-7 gap-3">
             {images.map((image, index) => (
-              <button
-                key={`${image.url}-${index}`}
-                onClick={() => setActiveIndex(index)}
-                className={
-                  index === activeIndex
-                    ? 'relative h-20 rounded-xl overflow-hidden ring-2 ring-brand-olive'
-                    : 'relative h-20 rounded-xl overflow-hidden ring-1 ring-transparent hover:ring-gray-200'
-                }
+              <div
+                key={image.id}
+                draggable={canManage}
+                onDragStart={() => onThumbDragStart(index)}
+                onDragOver={(event) => {
+                  if (!canManage) return;
+                  event.preventDefault();
+                }}
+                onDrop={() => onThumbDrop(index)}
+                className={clsx(
+                  'relative h-20 rounded-xl overflow-hidden',
+                  index === activeIndex ? 'ring-2 ring-brand-olive' : 'ring-1 ring-transparent hover:ring-gray-200',
+                  draggingIndex === index && 'opacity-60',
+                )}
               >
-                <SmartImage src={image.url} alt={image.name || ''} className="w-full h-full object-cover" />
-              </button>
+                <button onClick={() => setActiveIndex(index)} className="w-full h-full">
+                  <SmartImage src={image.url} alt={image.name || ''} className="w-full h-full object-cover" />
+                </button>
+
+                {canManage && (
+                  <div className="absolute inset-x-0 top-0 flex items-center justify-between p-1 bg-black/35 text-white opacity-0 hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => handleDeleteImage(index)}
+                      className="p-1 rounded bg-black/40 hover:bg-red-500/80"
+                      title="删除图片"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                    <span className="inline-flex items-center gap-0.5 text-[10px] px-1 py-0.5 rounded bg-black/40">
+                      <GripVertical size={10} /> 拖拽
+                    </span>
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         </section>
       )}
+
+      <div className="text-right">
+        <button onClick={() => navigate('/gallery')} className="text-xs text-gray-400 hover:text-brand-olive">
+          返回图集列表
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add record-level edit lock APIs (`/api/admin/locks*`) and wire Admin page to view/release locks
- add gallery draft/publish workflow and editable gallery details (meta update, append image, delete image, reorder)
- update deployment docs with v2.9 rollout and verification steps for edit locks and gallery publish flow

## Verification
- npm run db:generate
- npm run lint
- npm test
- npm run build