### PR TITLE
fix: add type filter support to GET /api/notifications

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -3423,10 +3423,12 @@ app.get('/api/notifications', requireAuth, async (req: AuthenticatedRequest, res
     const page = Math.max(Number(req.query.page) || 1, 1);
     const skip = (page - 1) * limit;
     const unreadOnly = req.query.unread === 'true';
+    const typeFilter = typeof req.query.type === 'string' && req.query.type ? req.query.type : null;
 
-    const where = {
+    const where: Record<string, unknown> = {
       userUid,
       ...(unreadOnly ? { isRead: false } : {}),
+      ...(typeFilter ? { type: typeFilter } : {}),
     };
 
     const [notifications, total, unreadCount] = await Promise.all([


### PR DESCRIPTION
## Summary
- Fixed `GET /api/notifications` to support `type` query parameter filtering
- Frontend was sending `?type=reply|like|review_result` but backend was ignoring it

## Changes
- Added `typeFilter` variable to read `req.query.type`
- Added `type` filter to Prisma `where` clause when `typeFilter` is provided

## Testing
- Lint passes
- Verified API endpoint now correctly filters notifications by type