### PR TITLE
feat(music): 歌曲跨平台关联功能

### DIFF
--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -1605,3 +1605,317 @@ tar -czf /root/backup/uploads_$(date +%F).tar.gz /root/huangshifu-wiki/uploads
 ```
 
 建议配合 `crontab` 做每日自动备份。
+
+---
+
+## 15. 地点标签功能（v4.0+）
+
+本次发布新增地点标签功能，支持为图集、帖子等内容设置地点标签。
+
+### 15.1 功能概述
+
+- **行政区划数据**：使用 `slightlee/regions-data` 四级行政区划数据（省/市/区县/乡镇）
+- **地点输入**：支持模糊搜索已有地点，也支持在地图上选点
+- **EXIF 提取**：支持从图片 EXIF GPS 数据自动提取拍摄地点
+- **地点显示**：地点标签以特殊样式显示（琥珀色区分普通标签）
+
+### 15.2 环境变量配置
+
+在 `.env` 中新增以下配置：
+
+```bash
+# 高德地图 - 前端 JS API（用于地图选点组件）
+VITE_AMAP_JS_API_KEY="your_amap_js_api_key"
+
+# 高德地图 - 后端 Web Service API（用于经纬度解析为行政区划）
+AMAP_API_KEY="your_amap_web_service_api_key"
+```
+
+**获取高德地图 API Key**：
+1. 注册高德开放平台账号：https://lbs.amap.com/
+2. 创建应用，获取 Web JS API Key 和 Web Service API Key
+
+### 15.3 数据库变更（已包含在 `db:deploy` 中）
+
+| 表名 | 变更类型 | 说明 |
+|------|---------|------|
+| `Region` | 新建表 | 行政区划表，存储全国四级行政区划数据 |
+| `Post` | 新增列 | `locationCode` String，可选，关联行政区划代码 |
+| `Gallery` | 新增列 | `locationCode` String，可选，关联行政区划代码 |
+| `WikiPage` | 新增列 | `locationCode` String，可选，关联行政区划代码 |
+
+**Region 表结构**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| code | String (PK) | 行政区划代码，如 "440300"（深圳市） |
+| name | String | 地名，如 "深圳市" |
+| fullName | String | 完整名称，如 "广东省深圳市" |
+| level | Int | 级别：1-省 2-市 3-区县 4-乡镇 |
+| depth | Int | 深度（同 level） |
+| parentCode | String | 上级代码，如 "440000"（广东省） |
+| path | String | 路径代码，如 "440000,440300" |
+| type | String | 类型名，如 "地级" |
+| year | Int | 数据年份 |
+| sortOrder | Int | 排序序号 |
+
+### 15.4 导入行政区划数据
+
+首次部署后需要导入行政区划数据：
+
+```bash
+cd /root/huangshifu-wiki
+npm run regions:import
+```
+
+该命令会：
+1. 从 `slightlee/regions-data` GitHub 仓库下载最新行政区划数据
+2. 解析并转换数据格式
+3. 清空并重新导入全部 42,935 条行政区划记录
+
+### 15.5 后端 API 变更
+
+| 端点 | 方法 | 功能 | 权限 |
+|------|------|------|------|
+| `/api/regions` | GET | 获取地点列表（支持模糊搜索） | 公开 |
+| `/api/regions/search` | GET | 模糊搜索地点 `?q=深圳` | 公开 |
+| `/api/regions/suggest` | GET | 获取地点建议 `?q=深` | 公开 |
+| `/api/regions/provinces` | GET | 获取省份列表 | 公开 |
+| `/api/regions/cities/:provinceCode` | GET | 获取城市列表 | 公开 |
+| `/api/regions/districts/:cityCode` | GET | 获取区县列表 | 公开 |
+| `/api/regions/path/:code` | GET | 获取完整行政区划路径 | 公开 |
+| `/api/regions/:code` | GET | 获取地点详情 | 公开 |
+| `/api/regions/resolve` | POST | 经纬度 → 行政区划 | 公开 |
+| `/api/regions/search/address` | GET | 搜索地址（高德） | 公开 |
+| `/api/exif/extract-gps` | POST | 从图片提取 GPS | 公开 |
+| `/api/exif/extract-gps-with-region` | POST | 提取 GPS 并解析行政区划 | 公开 |
+| `/api/exif/extract-single` | GET | 提取单张图片 GPS | 公开 |
+
+**创建/更新内容时传入地点**：
+
+```bash
+# 创建帖子时指定地点
+curl -X POST http://127.0.0.1:3000/api/posts \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"title":"测试帖子","section":"general","content":"内容","locationCode":"440300"}'
+
+# 更新图集时指定地点
+curl -X PATCH http://127.0.0.1:3000/api/galleries/<galleryId> \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"locationCode":"440305"}'
+```
+
+### 15.6 前端组件
+
+| 组件 | 位置 | 功能 |
+|------|------|------|
+| `LocationTagInput` | `src/components/LocationTagInput.tsx` | 地点输入框（模糊搜索+地图选点） |
+| `MapPickerModal` | `src/components/MapPickerModal.tsx` | 地图选点弹窗（基于高德地图 JS API） |
+| `LocationConfirmDialog` | `src/components/LocationConfirmDialog.tsx` | EXIF 提取后的地点确认弹窗 |
+
+### 15.7 验证步骤
+
+#### 15.7.1 行政区划数据导入验证
+
+```bash
+# 检查 Region 表记录数
+psql "postgresql://hsf_app:<密码>@127.0.0.1:5432/huangshifu_wiki" -c "SELECT COUNT(*) FROM \"Region\";"
+
+# 检查各层级分布
+psql "postgresql://hsf_app:<密码>@127.0.0.1:5432/huangshifu_wiki" -c "SELECT level, COUNT(*) FROM \"Region\" GROUP BY level ORDER BY level;"
+```
+
+预期结果：
+- 总记录数约 42,935 条
+- 省级 34 条、地级 333 条、县级 2,845 条、乡级约 38,723 条
+
+#### 15.7.2 地点 API 验证
+
+```bash
+# 搜索地点
+curl "http://127.0.0.1:3000/api/regions/search?q=深圳"
+
+# 获取省份
+curl "http://127.0.0.1:3000/api/regions/provinces"
+
+# 获取城市
+curl "http://127.0.0.1:3000/api/regions/cities/440000"
+
+# 经纬度解析（需要配置 AMAP_API_KEY）
+curl -X POST http://127.0.0.1:3000/api/regions/resolve \
+  -H "Content-Type: application/json" \
+  -d '{"lng":114.065,"lat":22.548}'
+```
+
+#### 15.7.3 前端地点功能验证
+
+1. 进入图集上传页面
+2. 在标签输入框下方找到「地点」输入框
+3. 输入"深圳"应显示模糊搜索建议
+4. 点击地图图标应打开地图选点弹窗
+5. 选择地点后，地点以琥珀色标签样式显示
+6. 创建图集后，地点信息保存成功
+
+#### 15.7.4 帖子地点功能验证
+
+1. 进入发帖页面
+2. 在标签输入框下方找到「地点」输入框
+3. 选择一个地点后提交帖子
+4. 帖子详情页应显示地点标签
+
+### 15.8 EXIF GPS 提取功能验证
+
+EXIF GPS 提取需要：
+1. 图片包含 GPS 元数据
+2. 已配置 `AMAP_API_KEY`（用于将 GPS 坐标解析为行政区划）
+
+```bash
+# 提取单张图片 GPS
+curl "http://127.0.0.1:3000/api/exif/extract-single?url=https://example.com/photo_with_gps.jpg"
+```
+
+**验证点**：
+- 没有 GPS 信息的图片返回 `gps: null`
+- 有 GPS 信息的图片返回经纬度
+- `extract-gps-with-region` 可直接返回对应的行政区划信息
+
+### 16.1 歌曲跨平台关联功能（v3.x）
+
+本次发布新增歌曲跨平台关联功能，支持手动关联和自动匹配。
+
+**功能说明：**
+
+- **编辑歌曲时关联**：在歌曲编辑弹窗中，可手动填写其他平台的歌曲 ID
+- **自动匹配搜索**：点击「匹配」按钮，在目标平台搜索相似歌曲并自动填入 ID
+- **平台 ID 冲突检测**：如果填入的 ID 已被其他歌曲使用，提示冲突
+- **导入时自动关联**：导入歌曲时，如果发现同歌曲其他平台版本，自动关联（不创建重复记录）
+- **歌曲列表显示**：歌曲卡片上显示已关联的平台标签（可点击跳转）
+- **关联管理页面**：新增 `/music/links` 页面，表格展示所有歌曲的平台关联状态
+
+**数据库变更：**
+
+- 无新增表，平台 ID 字段（`neteaseId`、`tencentId`、`kugouId`、`baiduId`、`kuwoId`）已在 `MusicTrack` 模型中存在
+
+**后端 API 变更：**
+
+| 端点 | 方法 | 功能 | 权限 |
+|------|------|------|------|
+| `GET /api/music/match-suggestions` | GET | 搜索跨平台匹配歌曲 | 公开 |
+| `PATCH /api/music/:docId` | PATCH | 编辑歌曲信息（支持平台 ID） | 管理员 |
+| `POST /api/music/import` | POST | 导入歌曲（支持自动关联） | 管理员 |
+
+**新增端点详细说明：**
+
+#### `GET /api/music/match-suggestions`
+
+根据歌名和艺术家在指定平台搜索匹配的歌曲。
+
+**请求参数：**
+
+| 参数 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `platform` | string | 是 | 目标平台：`netease`、`tencent`、`kugou`、`baidu`、`kuwo` |
+| `title` | string | 是 | 歌曲标题 |
+| `artist` | string | 是 | 艺术家名称 |
+
+**响应：**
+
+```json
+{
+  "suggestions": [
+    {
+      "sourceId": "12345678",
+      "title": "歌曲名",
+      "artist": "歌手名",
+      "album": "专辑名",
+      "cover": "封面URL",
+      "sourceUrl": "平台歌曲页URL",
+      "score": 85,
+      "isAutoSelected": true,
+      "alreadyLinked": { "docId": "xxx", "title": "已关联的歌曲" }
+    }
+  ],
+  "autoSelectedIndex": 0
+}
+```
+
+**匹配度计算：**
+- 标题 + 艺术家各占 50% 权重
+- 相似度 ≥80% 且明显高于其他结果时，`isAutoSelected: true`
+- `alreadyLinked` 表示该 ID 已关联到其他歌曲
+
+#### `PATCH /api/music/:docId` 平台 ID 字段
+
+在原有字段基础上，新增以下平台 ID 字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `neteaseId` | string \| null | 网易云音乐歌曲 ID |
+| `tencentId` | string \| null | QQ 音乐歌曲 ID |
+| `kugouId` | string \| null | 酷狗音乐歌曲 ID |
+| `baiduId` | string \| null | 百度音乐歌曲 ID |
+| `kuwoId` | string \| null | 酷我音乐歌曲 ID |
+
+**冲突响应（状态码 409）：**
+
+```json
+{
+  "error": "该平台ID已被歌曲「歌曲名」使用",
+  "conflict": true,
+  "conflictingSong": {
+    "docId": "xxx",
+    "title": "歌曲名",
+    "artist": "艺术家"
+  }
+}
+```
+
+**前端新增组件：**
+
+| 组件 | 位置 | 功能 |
+|------|------|------|
+| `MatchSuggestionModal` | `src/components/MatchSuggestionModal.tsx` | 跨平台匹配搜索弹窗 |
+| `MusicLinks` | `src/pages/MusicLinks.tsx` | 歌曲关联管理页面 |
+
+**前端页面变更：**
+
+| 页面 | 变更 |
+|------|------|
+| `Music.tsx` | 歌曲卡片新增平台标签显示；新增「关联管理」按钮 |
+| `MusicDetail.tsx` | `SongItem` 类型新增 `platformIds` 字段 |
+| `SongEditModal.tsx` | 新增「关联平台」可折叠区域；平台 ID 输入框和匹配按钮 |
+
+**新增路由：**
+
+| 路径 | 页面 | 说明 |
+|------|------|------|
+| `/music/links` | MusicLinks | 歌曲关联管理页面 |
+
+**验证步骤：**
+
+1. **手动关联验证**：
+   - 进入歌曲详情页，点击「编辑歌曲」
+   - 展开「关联平台」区域
+   - 填写某个平台的歌曲 ID（如网易云 ID），点击保存
+   - 预期：刷新后歌曲卡片显示该平台标签
+
+2. **自动匹配验证**：
+   - 在歌曲编辑弹窗中，点击某平台行的「匹配」按钮
+   - 弹出匹配搜索弹窗，显示搜索结果
+   - 选择正确的结果并确认
+   - 预期：ID 自动填入输入框
+
+3. **冲突检测验证**：
+   - 尝试将一个已被其他歌曲使用的平台 ID 填入
+   - 预期：显示错误提示「该平台ID已被歌曲「XXX」使用」
+
+4. **导入自动关联验证**：
+   - 导入一首已有其他平台版本的歌曲
+   - 预期：该歌曲的平台 ID 被更新，而非创建新记录
+
+5. **关联管理页面验证**：
+   - 进入音乐馆，点击「关联管理」按钮
+   - 预期：显示 `/music/links` 页面，表格展示所有歌曲的平台关联状态
+   - 可按平台、关联状态筛选

--- a/server.ts
+++ b/server.ts
@@ -28,7 +28,10 @@ import {
   resolveAudioUrl as resolveMetingAudioUrl,
   resolveLyric as resolveMetingLyric,
   resolveCoverUrl as resolveMetingCoverUrl,
+  searchMusicResources,
 } from './src/server/music/metingService';
+import { registerRegionRoutes } from './src/server/location/routes';
+import { registerExifRoutes } from './src/server/location/exifRoutes';
 
 dotenv.config({ path: '.env.local' });
 dotenv.config();
@@ -399,6 +402,7 @@ type WikiResponseInput = {
   tags: unknown;
   relations?: unknown;
   eventDate: string | null;
+  locationCode?: string | null;
   status: ContentStatus;
   reviewNote: string | null;
   reviewedBy: string | null;
@@ -409,6 +413,7 @@ type WikiResponseInput = {
   lastEditorName: string;
   createdAt: Date;
   updatedAt: Date;
+  location?: { code: string; name: string; fullName: string } | null;
 };
 
 type WikiReverseRelationEntry = {
@@ -1653,7 +1658,7 @@ async function createOrUpdateImportedSong(params: {
   const sourceField = getPlatformSourceField(platform);
   const platformId = track.sourceId;
 
-  const existing = await prismaAny.musicTrack.findFirst({
+  const existingByPlatformId = await prismaAny.musicTrack.findFirst({
     where: {
       OR: [
         { [sourceField]: platformId },
@@ -1662,36 +1667,114 @@ async function createOrUpdateImportedSong(params: {
     },
   });
 
+  if (existingByPlatformId) {
+    const fallbackTitle = `未命名歌曲 ${track.sourceId}`;
+    const title = track.title || fallbackTitle;
+    const artist = track.artist || '未知歌手';
+    const album = track.album || albumNameFallback || '未知专辑';
+
+    const resolvedCover = (await resolveMetingCoverUrl(platform as ParsedMusicPlatform, track.picId, track.cover)) || track.cover;
+    const resolvedAudioUrl = (await resolveMetingAudioUrl(platform as ParsedMusicPlatform, track.urlId)) || '';
+    const resolvedLyric = (await resolveMetingLyric(platform as ParsedMusicPlatform, track.lyricId)) || '';
+
+    const song = await prismaAny.musicTrack.update({
+      where: { docId: existingByPlatformId.docId },
+      data: {
+        id: existingByPlatformId.id || track.sourceId,
+        title,
+        artist,
+        album,
+        cover: resolvedCover || '',
+        audioUrl: resolvedAudioUrl || '',
+        lyric: resolvedLyric || null,
+        primaryPlatform: platform,
+        enabledPlatform: platform,
+        [sourceField]: platformId,
+      },
+    });
+    return {
+      song,
+      created: false,
+      linked: false,
+    };
+  }
+
   const fallbackTitle = `未命名歌曲 ${track.sourceId}`;
   const title = track.title || fallbackTitle;
   const artist = track.artist || '未知歌手';
   const album = track.album || albumNameFallback || '未知专辑';
 
+  const existingByTitleArtist = await prismaAny.musicTrack.findFirst({
+    where: {
+      AND: [
+        { title: { equals: title } },
+        { artist: { equals: artist } },
+        {
+          OR: [
+            { neteaseId: { not: null } },
+            { tencentId: { not: null } },
+            { kugouId: { not: null } },
+            { baiduId: { not: null } },
+            { kuwoId: { not: null } },
+          ],
+        },
+      ],
+    } as Prisma.MusicTrackWhereInput,
+  });
+
   const resolvedCover = (await resolveMetingCoverUrl(platform as ParsedMusicPlatform, track.picId, track.cover)) || track.cover;
   const resolvedAudioUrl = (await resolveMetingAudioUrl(platform as ParsedMusicPlatform, track.urlId)) || '';
   const resolvedLyric = (await resolveMetingLyric(platform as ParsedMusicPlatform, track.lyricId)) || '';
 
-  const updateData: Record<string, unknown> = {
-    id: existing?.id || track.sourceId,
-    title,
-    artist,
-    album,
-    cover: resolvedCover || '',
-    audioUrl: resolvedAudioUrl || '',
-    lyric: resolvedLyric || null,
-    primaryPlatform: platform,
-    enabledPlatform: platform,
-    [sourceField]: platformId,
-  };
+  if (existingByTitleArtist) {
+    const conflictPlatformId = (existingByTitleArtist as Record<string, string | null>)[sourceField];
+    if (conflictPlatformId) {
+      const song = await prismaAny.musicTrack.create({
+        data: {
+          id: track.sourceId,
+          title,
+          artist,
+          album,
+          cover: resolvedCover || '',
+          audioUrl: resolvedAudioUrl || '',
+          lyric: resolvedLyric || null,
+          primaryPlatform: platform,
+          enabledPlatform: platform,
+          [sourceField]: platformId,
+          addedBy: userUid,
+        },
+      });
+      return {
+        song,
+        created: true,
+        linked: false,
+      };
+    }
 
-  if (existing) {
-    const song = await prismaAny.musicTrack.update({
-      where: { docId: existing.docId },
-      data: updateData,
+    const updatedSong = await prismaAny.musicTrack.update({
+      where: { docId: existingByTitleArtist.docId },
+      data: {
+        id: existingByTitleArtist.id || track.sourceId,
+        title,
+        artist,
+        album,
+        cover: resolvedCover || '',
+        audioUrl: resolvedAudioUrl || '',
+        lyric: resolvedLyric || null,
+        primaryPlatform: platform,
+        enabledPlatform: platform,
+        [sourceField]: platformId,
+      },
     });
     return {
-      song,
+      song: updatedSong,
       created: false,
+      linked: true,
+      linkedFrom: {
+        docId: existingByTitleArtist.docId,
+        title: existingByTitleArtist.title,
+        artist: existingByTitleArtist.artist,
+      },
     };
   }
 
@@ -1714,6 +1797,7 @@ async function createOrUpdateImportedSong(params: {
   return {
     song,
     created: true,
+    linked: false,
   };
 }
 
@@ -2342,6 +2426,8 @@ function toWikiResponse(page: WikiResponseInput) {
     tags: serializeTags(page.tags),
     relations: serializeRelations(page.relations, page.slug),
     eventDate: page.eventDate,
+    locationCode: page.locationCode || null,
+    locationName: page.location?.fullName || null,
     status: page.status,
     reviewNote: page.reviewNote,
     reviewedBy: page.reviewedBy,
@@ -2472,6 +2558,7 @@ function toPostResponse(post: {
   albumDocId?: string | null;
   content: string;
   tags: unknown;
+  locationCode?: string | null;
   authorUid: string;
   status: ContentStatus;
   reviewNote: string | null;
@@ -2485,9 +2572,12 @@ function toPostResponse(post: {
   isPinned?: boolean;
   createdAt: Date;
   updatedAt: Date;
+  location?: { code: string; name: string; fullName: string } | null;
 }) {
   return {
     ...post,
+    locationCode: post.locationCode || null,
+    locationName: post.location?.fullName || null,
     hotScore: post.hotScore ?? 0,
     viewCount: post.viewCount ?? 0,
     tags: serializeTags(post.tags),
@@ -2522,10 +2612,12 @@ function toGalleryResponse(gallery: {
   authorUid: string;
   authorName: string;
   tags: unknown;
+  locationCode?: string | null;
   published: boolean;
   publishedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  location?: { code: string; name: string; fullName: string } | null;
   images: {
     id: string;
     url: string;
@@ -2549,6 +2641,8 @@ function toGalleryResponse(gallery: {
     authorUid: gallery.authorUid,
     authorName: gallery.authorName,
     tags: serializeTags(gallery.tags),
+    locationCode: gallery.locationCode || null,
+    locationName: gallery.location?.fullName || null,
     published: gallery.published,
     publishedAt: gallery.publishedAt ? gallery.publishedAt.toISOString() : null,
     createdAt: gallery.createdAt.toISOString(),
@@ -2632,6 +2726,9 @@ function toEditLockResponse(lock: {
 }
 
 app.use(authMiddleware);
+
+registerRegionRoutes(app);
+registerExifRoutes(app);
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
@@ -3947,6 +4044,7 @@ app.post('/api/wiki', requireAuth, requireActiveUser, async (req: AuthenticatedR
       relations,
       eventDate,
       status,
+      locationCode,
     } = req.body as {
       title?: string;
       slug?: string;
@@ -3956,6 +4054,7 @@ app.post('/api/wiki', requireAuth, requireActiveUser, async (req: AuthenticatedR
       relations?: unknown;
       eventDate?: string;
       status?: ContentStatus;
+      locationCode?: string;
     };
 
     if (!title || !slug || !category || !content) {
@@ -3999,6 +4098,7 @@ app.post('/api/wiki', requireAuth, requireActiveUser, async (req: AuthenticatedR
         reviewedAt: null,
         lastEditorUid: req.authUser!.uid,
         lastEditorName: req.authUser!.displayName,
+        locationCode: locationCode || null,
       },
       update: {
         title,
@@ -4013,6 +4113,7 @@ app.post('/api/wiki', requireAuth, requireActiveUser, async (req: AuthenticatedR
         reviewedAt: null,
         lastEditorUid: req.authUser!.uid,
         lastEditorName: req.authUser!.displayName,
+        locationCode: locationCode || null,
       },
     });
 
@@ -4185,6 +4286,7 @@ app.put('/api/wiki/:slug', requireAuth, requireActiveUser, async (req: Authentic
       relations,
       eventDate,
       status,
+      locationCode,
     } = req.body as {
       title?: string;
       category?: string;
@@ -4193,6 +4295,7 @@ app.put('/api/wiki/:slug', requireAuth, requireActiveUser, async (req: Authentic
       relations?: unknown;
       eventDate?: string;
       status?: ContentStatus;
+      locationCode?: string;
     };
 
     if (!title || !category || !content) {
@@ -4231,6 +4334,7 @@ app.put('/api/wiki/:slug', requireAuth, requireActiveUser, async (req: Authentic
         reviewedAt: null,
         lastEditorUid: req.authUser!.uid,
         lastEditorName: req.authUser!.displayName,
+        locationCode: locationCode || null,
       },
     });
 
@@ -6978,13 +7082,14 @@ app.post('/api/galleries/upload', requireAuth, requireActiveUser, upload.array('
 
 app.post('/api/galleries', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
   try {
-    const { title, description, tags, images, assetIds, uploadSessionId } = req.body as {
+    const { title, description, tags, images, assetIds, uploadSessionId, locationCode } = req.body as {
       title?: string;
       description?: string;
       tags?: string[];
       images?: { url: string; name: string }[];
       assetIds?: string[];
       uploadSessionId?: string;
+      locationCode?: string;
     };
 
     const normalizedAssetIds = parseAssetIdList(assetIds);
@@ -7055,6 +7160,7 @@ app.post('/api/galleries', requireAuth, requireActiveUser, async (req: Authentic
           authorUid: req.authUser!.uid,
           authorName: req.authUser!.displayName,
           tags: finalTags,
+          locationCode: locationCode || null,
           images: {
             create: orderedAssets.map((asset, index) => ({
               assetId: asset.id,
@@ -7141,6 +7247,7 @@ app.post('/api/galleries', requireAuth, requireActiveUser, async (req: Authentic
         authorUid: req.authUser!.uid,
         authorName: req.authUser!.displayName,
         tags: normalizedTags,
+        locationCode: locationCode || null,
         images: {
           create: normalizedImages.map((image, index) => ({
             assetId: assetByUrl.get(image.url) || null,
@@ -7199,11 +7306,13 @@ app.patch('/api/galleries/:id', requireAuth, requireActiveUser, async (req: Auth
     const title = typeof req.body?.title === 'string' ? req.body.title.trim() : undefined;
     const description = typeof req.body?.description === 'string' ? req.body.description.trim() : undefined;
     const tags = req.body?.tags !== undefined ? normalizeTagList(req.body.tags) : undefined;
+    const locationCode = req.body?.locationCode !== undefined ? (typeof req.body.locationCode === 'string' && req.body.locationCode.length > 0 ? req.body.locationCode : null) : undefined;
 
     const data: {
       title?: string;
       description?: string;
       tags?: string[];
+      locationCode?: string | null;
     } = {};
 
     if (title !== undefined && title.length > 0) {
@@ -7214,6 +7323,9 @@ app.patch('/api/galleries/:id', requireAuth, requireActiveUser, async (req: Auth
     }
     if (tags !== undefined) {
       data.tags = tags;
+    }
+    if (locationCode !== undefined) {
+      data.locationCode = locationCode;
     }
 
     if (!Object.keys(data).length) {
@@ -8034,8 +8146,10 @@ app.post('/api/music/import', requireAdmin, async (req: AuthenticatedRequest, re
     let imported = 0;
     let skipped = 0;
     let failed = 0;
+    let linked = 0;
 
     const importedSongs: Array<{ docId: string; trackOrder: number }> = [];
+    const linkedSongs: Array<{ docId: string; title: string; artist: string; platform: string }> = [];
     for (let index = 0; index < tracks.length; index += 1) {
       const track = tracks[index];
       try {
@@ -8049,6 +8163,15 @@ app.post('/api/music/import', requireAdmin, async (req: AuthenticatedRequest, re
           imported += 1;
         } else {
           skipped += 1;
+        }
+        if (result.linked) {
+          linked += 1;
+          linkedSongs.push({
+            docId: result.song.docId,
+            title: result.song.title,
+            artist: result.song.artist,
+            platform: preview.platform,
+          });
         }
         importedSongs.push({ docId: result.song.docId, trackOrder: index });
       } catch (error) {
@@ -8520,6 +8643,38 @@ app.patch('/api/music/:docId', requireAdmin, async (req, res) => {
     if (baiduId) updateData.baiduId = baiduId;
     if (kuwoId) updateData.kuwoId = kuwoId;
 
+    const platformIdFields: Array<{ field: string; value: string }> = [];
+    if (neteaseId) platformIdFields.push({ field: 'neteaseId', value: neteaseId });
+    if (tencentId) platformIdFields.push({ field: 'tencentId', value: tencentId });
+    if (kugouId) platformIdFields.push({ field: 'kugouId', value: kugouId });
+    if (baiduId) platformIdFields.push({ field: 'baiduId', value: baiduId });
+    if (kuwoId) platformIdFields.push({ field: 'kuwoId', value: kuwoId });
+
+    if (platformIdFields.length > 0) {
+      for (const { field, value } of platformIdFields) {
+        if (!value) continue;
+        const conflict = await prismaAny.musicTrack.findFirst({
+          where: {
+            docId: { not: docId },
+            [field]: value,
+          },
+          select: { docId: true, title: true, artist: true },
+        });
+        if (conflict) {
+          res.status(409).json({
+            error: `该平台ID已被歌曲「${conflict.title}」使用`,
+            conflict: true,
+            conflictingSong: {
+              docId: conflict.docId,
+              title: conflict.title,
+              artist: conflict.artist,
+            },
+          });
+          return;
+        }
+      }
+    }
+
     await prismaAny.musicTrack.update({
       where: { docId },
       data: updateData,
@@ -8537,6 +8692,143 @@ app.patch('/api/music/:docId', requireAdmin, async (req, res) => {
     res.status(500).json({ error: '更新歌曲失败' });
   }
 });
+
+app.get('/api/music/match-suggestions', async (req: AuthenticatedRequest, res) => {
+  try {
+    const platform = typeof req.query.platform === 'string' ? req.query.platform.trim() : '';
+    const title = typeof req.query.title === 'string' ? req.query.title.trim() : '';
+    const artist = typeof req.query.artist === 'string' ? req.query.artist.trim() : '';
+    const docId = typeof req.query.docId === 'string' ? req.query.docId.trim() : '';
+
+    if (!platform || !title || !artist) {
+      res.status(400).json({ error: '缺少必要参数：platform, title, artist' });
+      return;
+    }
+
+    const validPlatforms = ['netease', 'tencent', 'kugou', 'baidu', 'kuwo'];
+    if (!validPlatforms.includes(platform)) {
+      res.status(400).json({ error: '无效的平台' });
+      return;
+    }
+
+    const searchResults = await searchMusicResources({
+      platform: platform as MusicPlatform,
+      keyword: `${title} ${artist}`,
+      type: 'song',
+      limit: 10,
+    });
+
+    const normalizedTitle = title.toLowerCase().replace(/\s+/g, '');
+    const normalizedArtist = artist.toLowerCase().replace(/\s+/g, '');
+
+    const scored = searchResults
+      .map((item) => {
+        const itemTitleNorm = item.title.toLowerCase().replace(/\s+/g, '');
+        const itemArtistNorm = item.artist.toLowerCase().replace(/\s+/g, '');
+        const titleScore = calculateSimilarity(normalizedTitle, itemTitleNorm);
+        const artistScore = calculateSimilarity(normalizedArtist, itemArtistNorm);
+        const avgScore = (titleScore + artistScore) / 2;
+        return { ...item, score: avgScore };
+      })
+      .filter((item) => item.score >= 0.5)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 5);
+
+    let autoSelectedIndex: number | null = null;
+    if (scored.length === 1 && scored[0].score >= 0.8) {
+      autoSelectedIndex = 0;
+    } else if (scored.length > 1 && scored[0].score >= 0.85 && scored[1].score < scored[0].score - 0.15) {
+      autoSelectedIndex = 0;
+    }
+
+    const existingSongsByPlatformId = await prismaAny.musicTrack.findMany({
+      where: {
+        OR: scored.map((item) => {
+          const field = getPlatformSourceField(platform as MusicPlatform);
+          return { [field]: item.sourceId };
+        }),
+      },
+      select: { docId: true, id: true, title: true, artist: true },
+    });
+
+    const existingMap = new Map<string, { docId: string; title: string; artist: string }>();
+    for (const s of existingSongsByPlatformId) {
+      existingMap.set(s.id, { docId: s.docId, title: s.title, artist: s.artist });
+    }
+
+    const suggestions = scored.map((item, index) => {
+      const existing = existingMap.get(item.sourceId);
+      return {
+        sourceId: item.sourceId,
+        title: item.title,
+        artist: item.artist,
+        album: item.album,
+        cover: item.picId,
+        sourceUrl: item.sourceUrl,
+        score: Math.round(item.score * 100),
+        isAutoSelected: index === autoSelectedIndex,
+        alreadyLinked: existing ? { docId: existing.docId, title: existing.title } : null,
+      };
+    });
+
+    res.json({ suggestions, autoSelectedIndex });
+  } catch (error) {
+    console.error('Match suggestions error:', error);
+    res.status(500).json({ error: '搜索匹配歌曲失败' });
+  }
+});
+
+function calculateSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length === 0 || b.length === 0) return 0;
+
+  const maxLen = Math.max(a.length, b.length);
+  if (maxLen > 50) {
+    return a.includes(b) || b.includes(a) ? 0.85 : 0;
+  }
+
+  const d = Math.max(a.length, b.length);
+  let similarity = 0;
+
+  if (d <= 200) {
+    similarity = levenshteinSimilarity(a, b);
+  } else {
+    const aSub = a.slice(0, 50);
+    const bSub = b.slice(0, 50);
+    similarity = levenshteinSimilarity(aSub, bSub);
+  }
+
+  if (a.includes(b) || b.includes(a)) {
+    similarity = Math.max(similarity, 0.85);
+  }
+
+  return similarity;
+}
+
+function levenshteinSimilarity(a: string, b: string): number {
+  const matrix: number[][] = [];
+  for (let i = 0; i <= b.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= a.length; j++) {
+    matrix[0][j] = j;
+  }
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j] + 1,
+        );
+      }
+    }
+  }
+  const distance = matrix[b.length][a.length];
+  return 1 - distance / Math.max(a.length, b.length);
+}
 
 app.get('/api/music/:docId/covers', async (req, res) => {
   try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import GalleryDetail from './pages/GalleryDetail';
 import Music from './pages/Music';
 import AlbumDetail from './pages/AlbumDetail';
 import MusicDetail from './pages/MusicDetail';
+import MusicLinks from './pages/MusicLinks';
 import Search from './pages/Search';
 import Admin from './pages/Admin';
 
@@ -38,6 +39,7 @@ const MainLayout = () => {
           <Route path="/gallery/:galleryId" element={<GalleryDetail />} />
           <Route path="/music" element={<Music />} />
           <Route path="/music/:songId" element={<MusicDetail />} />
+          <Route path="/music/links" element={<MusicLinks />} />
           <Route path="/album/:albumId" element={<AlbumDetail />} />
           <Route path="/search" element={<Search />} />
           <Route path="/profile" element={<Profile />} />

--- a/src/components/MatchSuggestionModal.tsx
+++ b/src/components/MatchSuggestionModal.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import { ExternalLink, Loader2, Search, X, Check, AlertCircle } from 'lucide-react';
+
+import { apiGet } from '../lib/apiClient';
+
+type Platform = 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo';
+
+type MatchSuggestion = {
+  sourceId: string;
+  title: string;
+  artist: string;
+  album: string;
+  cover: string;
+  sourceUrl: string;
+  score: number;
+  isAutoSelected: boolean;
+  alreadyLinked: { docId: string; title: string } | null;
+};
+
+type MatchSuggestionsResponse = {
+  suggestions: MatchSuggestion[];
+  autoSelectedIndex: number | null;
+};
+
+interface MatchSuggestionModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  artist: string;
+  targetPlatform: Platform;
+  existingPlatformId?: string | null;
+  onSelect: (sourceId: string) => void;
+}
+
+const platformLabels: Record<Platform, string> = {
+  netease: '网易云音乐',
+  tencent: 'QQ音乐',
+  kugou: '酷狗音乐',
+  baidu: '百度音乐',
+  kuwo: '酷我音乐',
+};
+
+function buildPlatformSongUrl(platform: Platform, id: string): string {
+  if (platform === 'netease') return `https://music.163.com/song?id=${id}`;
+  if (platform === 'tencent') return `https://y.qq.com/n/ryqq/songDetail/${id}`;
+  if (platform === 'kugou') return `https://www.kugou.com/song/#hash=${id}`;
+  if (platform === 'baidu') return `https://music.baidu.com/song/${id}`;
+  return `https://www.kuwo.cn/song_detail/${id}`;
+}
+
+export const MatchSuggestionModal = ({
+  open,
+  onClose,
+  title,
+  artist,
+  targetPlatform,
+  existingPlatformId,
+  onSelect,
+}: MatchSuggestionModalProps) => {
+  const [loading, setLoading] = useState(false);
+  const [suggestions, setSuggestions] = useState<MatchSuggestion[]>([]);
+  const [error, setError] = useState('');
+  const [searched, setSearched] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  React.useEffect(() => {
+    if (open && !searched) {
+      handleSearch();
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) {
+      setSuggestions([]);
+      setSearched(false);
+      setError('');
+      setSelectedIndex(null);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (searched && suggestions.length > 0) {
+      const autoIdx = suggestions.findIndex((s) => s.isAutoSelected);
+      if (autoIdx >= 0) {
+        setSelectedIndex(autoIdx);
+      }
+    }
+  }, [searched, suggestions]);
+
+  const handleSearch = async () => {
+    setLoading(true);
+    setError('');
+    setSearched(false);
+
+    try {
+      const data = await apiGet<MatchSuggestionsResponse>('/api/music/match-suggestions', {
+        platform: targetPlatform,
+        title,
+        artist,
+      });
+      setSuggestions(data.suggestions || []);
+      setSearched(true);
+      if (data.suggestions.length === 0) {
+        setError(`在${platformLabels[targetPlatform]}未找到匹配歌曲`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '搜索失败');
+      setSuggestions([]);
+      setSearched(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (selectedIndex === null) return;
+    onSelect(suggestions[selectedIndex].sourceId);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[130] bg-black/60 backdrop-blur-sm p-4 flex items-center justify-center">
+      <div className="w-full max-w-lg max-h-[90vh] overflow-hidden bg-white rounded-[36px] shadow-2xl border border-gray-100 flex flex-col">
+        <header className="px-6 py-5 border-b border-gray-100 flex items-center justify-between">
+          <div>
+            <h3 className="text-2xl font-serif font-bold text-gray-900">搜索匹配歌曲</h3>
+            <p className="text-xs text-gray-500 mt-1">
+              在{platformLabels[targetPlatform]}搜索：{title} - {artist}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </header>
+
+        <div className="px-6 py-5 space-y-4 overflow-y-auto flex-1">
+          {loading && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 size={32} className="animate-spin text-gray-400" />
+              <span className="ml-3 text-gray-500">搜索中...</span>
+            </div>
+          )}
+
+          {error && !loading && (
+            <div className="flex items-center gap-3 p-4 rounded-2xl bg-red-50 text-red-600">
+              <AlertCircle size={20} />
+              <span className="text-sm">{error}</span>
+            </div>
+          )}
+
+          {searched && suggestions.length > 0 && !loading && (
+            <div className="space-y-3">
+              {suggestions.map((suggestion, index) => (
+                <button
+                  key={suggestion.sourceId}
+                  onClick={() => setSelectedIndex(index)}
+                  className={`w-full text-left p-4 rounded-2xl border transition-all ${
+                    selectedIndex === index
+                      ? 'border-brand-primary bg-brand-primary/5 shadow-md'
+                      : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50'
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={`w-6 h-6 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                        selectedIndex === index
+                          ? 'border-brand-primary bg-brand-primary'
+                          : 'border-gray-300'
+                      }`}
+                    >
+                      {selectedIndex === index && <Check size={14} className="text-white" />}
+                    </div>
+                    <img
+                      src={suggestion.cover}
+                      alt=""
+                      className="w-12 h-12 rounded-xl object-cover shrink-0"
+                      referrerPolicy="no-referrer"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="font-bold text-gray-900 truncate">{suggestion.title}</p>
+                      <p className="text-xs text-gray-500 truncate">{suggestion.artist} · {suggestion.album}</p>
+                      <div className="flex items-center gap-2 mt-1">
+                        <span
+                          className={`text-xs px-2 py-0.5 rounded-full ${
+                            suggestion.score >= 80
+                              ? 'bg-green-100 text-green-700'
+                              : suggestion.score >= 60
+                              ? 'bg-yellow-100 text-yellow-700'
+                              : 'bg-gray-100 text-gray-600'
+                          }`}
+                        >
+                          匹配度 {suggestion.score}%
+                        </span>
+                        {suggestion.alreadyLinked && (
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700">
+                            已关联
+                          </span>
+                        )}
+                        {suggestion.isAutoSelected && (
+                          <span className="text-xs px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary">
+                            推荐
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <a
+                      href={buildPlatformSongUrl(targetPlatform, suggestion.sourceId)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="p-2 text-gray-400 hover:text-brand-primary transition-colors shrink-0"
+                    >
+                      <ExternalLink size={16} />
+                    </a>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {searched && suggestions.length === 0 && !loading && !error && (
+            <div className="text-center py-12 text-gray-400">
+              <Search size={48} className="mx-auto mb-3 opacity-50" />
+              <p>未找到匹配歌曲</p>
+            </div>
+          )}
+
+          {existingPlatformId && (
+            <div className="mt-4 p-3 rounded-xl bg-gray-50 border border-gray-100">
+              <p className="text-xs text-gray-500">
+                该平台已有ID: <span className="font-mono font-bold">{existingPlatformId}</span>
+              </p>
+            </div>
+          )}
+        </div>
+
+        <footer className="px-6 py-4 border-t border-gray-100 bg-gray-50/50 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-white"
+          >
+            取消
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={selectedIndex === null || loading}
+            className="px-5 py-2.5 rounded-xl bg-gray-900 text-white font-semibold hover:bg-gray-800 disabled:opacity-50 inline-flex items-center gap-2"
+          >
+            {loading ? <Loader2 size={16} className="animate-spin" /> : null}
+            {loading ? '处理中...' : '确认'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};

--- a/src/components/SongEditModal.tsx
+++ b/src/components/SongEditModal.tsx
@@ -1,8 +1,19 @@
 import React, { useState } from 'react';
-import { Loader2, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, ExternalLink, Loader2, Search, X } from 'lucide-react';
 
 import { apiPatch } from '../lib/apiClient';
 import { useToast } from './Toast';
+import { MatchSuggestionModal } from './MatchSuggestionModal';
+
+type Platform = 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo';
+
+type PlatformIds = {
+  neteaseId?: string | null;
+  tencentId?: string | null;
+  kugouId?: string | null;
+  baiduId?: string | null;
+  kuwoId?: string | null;
+};
 
 type SongFormData = {
   title: string;
@@ -20,8 +31,9 @@ type SongItem = {
   cover: string;
   audioUrl: string;
   lyric?: string | null;
-  primaryPlatform?: 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo' | null;
+  primaryPlatform?: Platform | null;
   favoritedByMe?: boolean;
+  platformIds?: PlatformIds;
 };
 
 interface SongEditModalProps {
@@ -31,6 +43,14 @@ interface SongEditModalProps {
   song: SongItem;
 }
 
+const platformFields: Array<{ key: keyof PlatformIds; label: string; urlPattern: (id: string) => string }> = [
+  { key: 'neteaseId', label: '网易云音乐', urlPattern: (id) => `https://music.163.com/song?id=${id}` },
+  { key: 'tencentId', label: 'QQ音乐', urlPattern: (id) => `https://y.qq.com/n/ryqq/songDetail/${id}` },
+  { key: 'kugouId', label: '酷狗音乐', urlPattern: (id) => `https://www.kugou.com/song/#hash=${id}` },
+  { key: 'baiduId', label: '百度音乐', urlPattern: (id) => `https://music.baidu.com/song/${id}` },
+  { key: 'kuwoId', label: '酷我音乐', urlPattern: (id) => `https://www.kuwo.cn/song_detail/${id}` },
+];
+
 export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalProps) => {
   const [formData, setFormData] = useState<SongFormData>({
     title: song.title || '',
@@ -38,6 +58,15 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
     album: song.album || '',
     lyric: song.lyric || '',
   });
+  const [platformIds, setPlatformIds] = useState<PlatformIds>({
+    neteaseId: song.platformIds?.neteaseId || '',
+    tencentId: song.platformIds?.tencentId || '',
+    kugouId: song.platformIds?.kugouId || '',
+    baiduId: song.platformIds?.baiduId || '',
+    kuwoId: song.platformIds?.kuwoId || '',
+  });
+  const [platformExpanded, setPlatformExpanded] = useState(false);
+  const [matchingPlatform, setMatchingPlatform] = useState<Platform | null>(null);
   const [saving, setSaving] = useState(false);
   const { show } = useToast();
 
@@ -48,6 +77,13 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
         artist: song.artist || '',
         album: song.album || '',
         lyric: song.lyric || '',
+      });
+      setPlatformIds({
+        neteaseId: song.platformIds?.neteaseId || '',
+        tencentId: song.platformIds?.tencentId || '',
+        kugouId: song.platformIds?.kugouId || '',
+        baiduId: song.platformIds?.baiduId || '',
+        kuwoId: song.platformIds?.kuwoId || '',
       });
     }
   }, [song, open]);
@@ -69,114 +105,203 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
 
     setSaving(true);
     try {
-      await apiPatch(`/api/music/${song.docId}`, {
+      const result = await apiPatch<{ song: SongItem; error?: string; conflict?: boolean; conflictingSong?: { docId: string; title: string; artist: string } }>(`/api/music/${song.docId}`, {
         title: formData.title.trim(),
         artist: formData.artist.trim(),
         album: formData.album.trim(),
         lyric: formData.lyric?.trim() || null,
+        neteaseId: platformIds.neteaseId || null,
+        tencentId: platformIds.tencentId || null,
+        kugouId: platformIds.kugouId || null,
+        baiduId: platformIds.baiduId || null,
+        kuwoId: platformIds.kuwoId || null,
       });
       show('歌曲已更新');
       onSuccess();
       onClose();
     } catch (error) {
-      console.error('Update song failed:', error);
-      show(error instanceof Error ? error.message : '保存失败', { variant: 'error' });
+      const err = error as { conflict?: boolean; conflictingSong?: { docId: string; title: string; artist: string }; message?: string };
+      if (err.conflict && err.conflictingSong) {
+        show(`该平台ID已被歌曲「${err.conflictingSong.title}」使用`, { variant: 'error' });
+      } else {
+        show(error instanceof Error ? error.message : '保存失败', { variant: 'error' });
+      }
     } finally {
       setSaving(false);
     }
   };
 
+  const handlePlatformIdChange = (key: keyof PlatformIds, value: string) => {
+    setPlatformIds((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleMatchSelect = (platform: Platform, sourceId: string) => {
+    handlePlatformIdChange(`${platform}Id` as keyof PlatformIds, sourceId);
+    setMatchingPlatform(null);
+  };
+
+  const linkedPlatforms = platformFields.filter((p) => platformIds[p.key]);
+
   return (
-    <div className="fixed inset-0 z-[120] bg-black/60 backdrop-blur-sm p-4 flex items-center justify-center">
-      <div className="w-full max-w-lg max-h-[90vh] overflow-hidden bg-white rounded-[36px] shadow-2xl border border-gray-100 flex flex-col">
-        <header className="px-6 py-5 border-b border-gray-100 flex items-center justify-between">
-          <div>
-            <h3 className="text-2xl font-serif font-bold text-gray-900">编辑歌曲</h3>
-            <p className="text-xs text-gray-500 mt-1">修改歌曲基本信息</p>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-2 rounded-full text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-          >
-            <X size={20} />
-          </button>
-        </header>
+    <>
+      <div className="fixed inset-0 z-[120] bg-black/60 backdrop-blur-sm p-4 flex items-center justify-center">
+        <div className="w-full max-w-lg max-h-[90vh] overflow-hidden bg-white rounded-[36px] shadow-2xl border border-gray-100 flex flex-col">
+          <header className="px-6 py-5 border-b border-gray-100 flex items-center justify-between">
+            <div>
+              <h3 className="text-2xl font-serif font-bold text-gray-900">编辑歌曲</h3>
+              <p className="text-xs text-gray-500 mt-1">修改歌曲基本信息</p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-full text-gray-400 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+            >
+              <X size={20} />
+            </button>
+          </header>
 
-        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-gray-700">歌曲标题 *</label>
-            <input
-              type="text"
-              value={formData.title}
-              onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
-              placeholder="歌曲名称"
-              className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
-            />
-          </div>
+          <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-gray-700">歌曲标题 *</label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+                placeholder="歌曲名称"
+                className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
+              />
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-gray-700">艺术家 *</label>
-            <input
-              type="text"
-              value={formData.artist}
-              onChange={(e) => setFormData((prev) => ({ ...prev, artist: e.target.value }))}
-              placeholder="歌手名称"
-              className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
-            />
-          </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-gray-700">艺术家 *</label>
+              <input
+                type="text"
+                value={formData.artist}
+                onChange={(e) => setFormData((prev) => ({ ...prev, artist: e.target.value }))}
+                placeholder="歌手名称"
+                className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
+              />
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-gray-700">专辑</label>
-            <input
-              type="text"
-              value={formData.album}
-              onChange={(e) => setFormData((prev) => ({ ...prev, album: e.target.value }))}
-              placeholder="所属专辑（可选）"
-              className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
-            />
-          </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-gray-700">专辑</label>
+              <input
+                type="text"
+                value={formData.album}
+                onChange={(e) => setFormData((prev) => ({ ...prev, album: e.target.value }))}
+                placeholder="所属专辑（可选）"
+                className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
+              />
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-semibold text-gray-700">歌词</label>
-            <textarea
-              value={formData.lyric || ''}
-              onChange={(e) => setFormData((prev) => ({ ...prev, lyric: e.target.value }))}
-              placeholder="歌词内容（可选，每行一句）"
-              rows={6}
-              className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 resize-none font-mono text-sm"
-            />
-          </div>
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-gray-700">歌词</label>
+              <textarea
+                value={formData.lyric || ''}
+                onChange={(e) => setFormData((prev) => ({ ...prev, lyric: e.target.value }))}
+                placeholder="歌词内容（可选，每行一句）"
+                rows={6}
+                className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 resize-none font-mono text-sm"
+              />
+            </div>
 
-          <div className="rounded-2xl border border-gray-100 bg-gray-50/60 p-4">
-            <div className="flex items-center gap-3">
-              <img src={song.cover} alt="" className="w-12 h-12 rounded-xl object-cover" referrerPolicy="no-referrer" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">{song.title}</p>
-                <p className="text-xs text-gray-500 truncate">{song.artist}</p>
-                <p className="text-xs text-gray-400 mt-1">ID: {song.id}</p>
+            <button
+              type="button"
+              onClick={() => setPlatformExpanded((prev) => !prev)}
+              className="w-full flex items-center justify-between p-4 rounded-2xl border border-gray-100 bg-gray-50/60 hover:bg-gray-100/60 transition-colors"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-gray-700">关联平台</span>
+                {linkedPlatforms.length > 0 && (
+                  <span className="text-xs px-2 py-0.5 rounded-full bg-brand-primary/20 text-brand-primary font-bold">
+                    已关联 {linkedPlatforms.length} 个
+                  </span>
+                )}
+              </div>
+              {platformExpanded ? <ChevronUp size={18} className="text-gray-400" /> : <ChevronDown size={18} className="text-gray-400" />}
+            </button>
+
+            {platformExpanded && (
+              <div className="space-y-3">
+                {platformFields.map((platform) => {
+                  const currentId = platformIds[platform.key] || '';
+                  const isLinked = Boolean(currentId);
+                  return (
+                    <div key={platform.key} className="flex items-center gap-3">
+                      <span className="w-24 text-sm text-gray-600 shrink-0">{platform.label}</span>
+                      <input
+                        type="text"
+                        value={currentId}
+                        onChange={(e) => handlePlatformIdChange(platform.key, e.target.value)}
+                        placeholder={isLinked ? '已关联' : '输入平台歌曲ID'}
+                        className="flex-1 px-3 py-2 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 text-sm font-mono"
+                      />
+                      {isLinked && (
+                        <a
+                          href={platform.urlPattern(currentId)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="p-2 text-gray-400 hover:text-brand-primary transition-colors"
+                        >
+                          <ExternalLink size={16} />
+                        </a>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setMatchingPlatform(platform.key.replace('Id', '') as Platform)}
+                        className="px-3 py-2 rounded-xl border border-gray-200 text-xs text-gray-600 hover:text-brand-primary hover:border-brand-primary/40 transition-colors flex items-center gap-1"
+                      >
+                        <Search size={14} />
+                        匹配
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            <div className="rounded-2xl border border-gray-100 bg-gray-50/60 p-4">
+              <div className="flex items-center gap-3">
+                <img src={song.cover} alt="" className="w-12 h-12 rounded-xl object-cover" referrerPolicy="no-referrer" />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">{song.title}</p>
+                  <p className="text-xs text-gray-500 truncate">{song.artist}</p>
+                  <p className="text-xs text-gray-400 mt-1">ID: {song.id}</p>
+                </div>
               </div>
             </div>
-          </div>
-        </form>
+          </form>
 
-        <footer className="px-6 py-4 border-t border-gray-100 bg-gray-50/50 flex justify-end gap-3">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-white"
-          >
-            取消
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={saving}
-            className="px-5 py-2.5 rounded-xl bg-gray-900 text-white font-semibold hover:bg-gray-800 disabled:opacity-50 inline-flex items-center gap-2"
-          >
-            {saving ? <Loader2 size={16} className="animate-spin" /> : null}
-            {saving ? '保存中...' : '保存'}
-          </button>
-        </footer>
+          <footer className="px-6 py-4 border-t border-gray-100 bg-gray-50/50 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-white"
+            >
+              取消
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={saving}
+              className="px-5 py-2.5 rounded-xl bg-gray-900 text-white font-semibold hover:bg-gray-800 disabled:opacity-50 inline-flex items-center gap-2"
+            >
+              {saving ? <Loader2 size={16} className="animate-spin" /> : null}
+              {saving ? '保存中...' : '保存'}
+            </button>
+          </footer>
+        </div>
       </div>
-    </div>
+
+      {matchingPlatform && (
+        <MatchSuggestionModal
+          open={true}
+          onClose={() => setMatchingPlatform(null)}
+          title={formData.title}
+          artist={formData.artist}
+          targetPlatform={matchingPlatform}
+          existingPlatformId={platformIds[`${matchingPlatform}Id` as keyof PlatformIds]}
+          onSelect={(sourceId) => handleMatchSelect(matchingPlatform, sourceId)}
+        />
+      )}
+    </>
   );
 };

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -42,6 +42,14 @@ interface FirestoreErrorInfo {
   }
 }
 
+type PlatformIds = {
+  neteaseId?: string | null;
+  tencentId?: string | null;
+  kugouId?: string | null;
+  baiduId?: string | null;
+  kuwoId?: string | null;
+};
+
 type SongItem = {
   docId: string;
   id: string;
@@ -53,6 +61,7 @@ type SongItem = {
   primaryPlatform?: 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo' | null;
   lyric?: string | null;
   favoritedByMe?: boolean;
+  platformIds?: PlatformIds;
 };
 
 type PostItem = {
@@ -437,6 +446,13 @@ const Music = () => {
               {isAdding ? <X size={20} /> : <Plus size={20} />}
               {isAdding ? '取消添加' : '添加音乐'}
             </button>
+            <Link
+              to="/music/links"
+              className="px-8 py-4 bg-white text-gray-900 border border-gray-200 rounded-full font-bold hover:scale-105 transition-all flex items-center gap-2 shadow-xl"
+            >
+              <Link2 size={20} />
+              关联管理
+            </Link>
           </div>
         )}
       </header>
@@ -653,6 +669,65 @@ const Music = () => {
                               {song.title}
                             </Link>
                             <p className="text-xs text-gray-400 mt-1 line-clamp-1">{song.artist} — {song.album}</p>
+                            {song.platformIds && (
+                              <div className="flex items-center gap-1.5 mt-2">
+                                {song.platformIds.neteaseId && (
+                                  <a
+                                    href={`https://music.163.com/song?id=${song.platformIds.neteaseId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors"
+                                    title={`网易云: ${song.platformIds.neteaseId}`}
+                                  >
+                                    网易云
+                                  </a>
+                                )}
+                                {song.platformIds.tencentId && (
+                                  <a
+                                    href={`https://y.qq.com/n/ryqq/songDetail/${song.platformIds.tencentId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 hover:bg-green-200 transition-colors"
+                                    title={`QQ音乐: ${song.platformIds.tencentId}`}
+                                  >
+                                    QQ
+                                  </a>
+                                )}
+                                {song.platformIds.kugouId && (
+                                  <a
+                                    href={`https://www.kugou.com/song/#hash=${song.platformIds.kugouId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
+                                    title={`酷狗: ${song.platformIds.kugouId}`}
+                                  >
+                                    酷狗
+                                  </a>
+                                )}
+                                {song.platformIds.baiduId && (
+                                  <a
+                                    href={`https://music.baidu.com/song/${song.platformIds.baiduId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs px-2 py-0.5 rounded-full bg-orange-100 text-orange-700 hover:bg-orange-200 transition-colors"
+                                    title={`百度: ${song.platformIds.baiduId}`}
+                                  >
+                                    百度
+                                  </a>
+                                )}
+                                {song.platformIds.kuwoId && (
+                                  <a
+                                    href={`https://www.kuwo.cn/song_detail/${song.platformIds.kuwoId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors"
+                                    title={`酷我: ${song.platformIds.kuwoId}`}
+                                  >
+                                    酷我
+                                  </a>
+                                )}
+                              </div>
+                            )}
                           </div>
 
                           <div className="mt-4 flex items-center justify-between gap-2">

--- a/src/pages/MusicDetail.tsx
+++ b/src/pages/MusicDetail.tsx
@@ -12,6 +12,14 @@ import { SongCoverManager } from '../components/SongCoverManager';
 import { SongEditModal } from '../components/SongEditModal';
 import { copyToClipboard, toAbsoluteInternalUrl } from '../lib/copyLink';
 
+type PlatformIds = {
+  neteaseId?: string | null;
+  tencentId?: string | null;
+  kugouId?: string | null;
+  baiduId?: string | null;
+  kuwoId?: string | null;
+};
+
 type SongItem = {
   docId: string;
   id: string;
@@ -23,10 +31,11 @@ type SongItem = {
   lyric?: string | null;
   primaryPlatform?: 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo' | null;
   favoritedByMe?: boolean;
+  platformIds?: PlatformIds;
 };
 
 type SongDetailResponse = {
-  song: SongItem;
+  song: SongItem & { platformIds?: PlatformIds };
 };
 
 type PostItem = {

--- a/src/pages/MusicLinks.tsx
+++ b/src/pages/MusicLinks.tsx
@@ -1,0 +1,296 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { ExternalLink, Filter, Link2, Loader2, Search } from 'lucide-react';
+import { clsx } from 'clsx';
+
+import { apiGet } from '../lib/apiClient';
+import { useAuth } from '../context/AuthContext';
+
+type Platform = 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo';
+
+type PlatformIds = {
+  neteaseId?: string | null;
+  tencentId?: string | null;
+  kugouId?: string | null;
+  baiduId?: string | null;
+  kuwoId?: string | null;
+};
+
+type SongItem = {
+  docId: string;
+  id: string;
+  title: string;
+  artist: string;
+  album: string;
+  cover: string;
+  primaryPlatform?: Platform | null;
+  platformIds?: PlatformIds;
+};
+
+const platformInfo: Array<{ key: keyof PlatformIds; label: string; color: string; bgColor: string }> = [
+  { key: 'neteaseId', label: '网易云', color: 'text-blue-700', bgColor: 'bg-blue-100' },
+  { key: 'tencentId', label: 'QQ音乐', color: 'text-green-700', bgColor: 'bg-green-100' },
+  { key: 'kugouId', label: '酷狗', color: 'text-red-700', bgColor: 'bg-red-100' },
+  { key: 'baiduId', label: '百度', color: 'text-orange-700', bgColor: 'bg-orange-100' },
+  { key: 'kuwoId', label: '酷我', color: 'text-purple-700', bgColor: 'bg-purple-100' },
+];
+
+function buildPlatformUrl(platform: Platform, id: string): string {
+  if (platform === 'netease') return `https://music.163.com/song?id=${id}`;
+  if (platform === 'tencent') return `https://y.qq.com/n/ryqq/songDetail/${id}`;
+  if (platform === 'kugou') return `https://www.kugou.com/song/#hash=${id}`;
+  if (platform === 'baidu') return `https://music.baidu.com/song/${id}`;
+  return `https://www.kuwo.cn/song_detail/${id}`;
+}
+
+const MusicLinks = () => {
+  const [songs, setSongs] = useState<SongItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filterPlatform, setFilterPlatform] = useState<Platform | 'all'>('all');
+  const [filterStatus, setFilterStatus] = useState<'all' | 'partial' | 'unlinked'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const { isAdmin } = useAuth();
+
+  useEffect(() => {
+    const fetchSongs = async () => {
+      setLoading(true);
+      try {
+        const data = await apiGet<{ songs: SongItem[] }>('/api/music');
+        setSongs(data.songs || []);
+      } catch (error) {
+        console.error('Fetch songs error:', error);
+        setSongs([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSongs();
+  }, []);
+
+  const filteredSongs = useMemo(() => {
+    let result = songs;
+
+    if (filterPlatform !== 'all') {
+      result = result.filter((song) => {
+        const fieldKey = `${filterPlatform}Id` as keyof PlatformIds;
+        return song.platformIds?.[fieldKey];
+      });
+    }
+
+    if (filterStatus === 'partial') {
+      result = result.filter((song) => {
+        const linkedCount = platformInfo.filter(
+          (p) => song.platformIds?.[p.key]
+        ).length;
+        return linkedCount > 0 && linkedCount < 5;
+      });
+    } else if (filterStatus === 'unlinked') {
+      result = result.filter((song) => {
+        return platformInfo.every((p) => !song.platformIds?.[p.key]);
+      });
+    }
+
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (song) =>
+          song.title.toLowerCase().includes(query) ||
+          song.artist.toLowerCase().includes(query)
+      );
+    }
+
+    return result;
+  }, [songs, filterPlatform, filterStatus, searchQuery]);
+
+  const stats = useMemo(() => {
+    const total = songs.length;
+    const linkedCount = songs.filter((song) =>
+      platformInfo.some((p) => song.platformIds?.[p.key])
+    ).length;
+    const partialCount = songs.filter((song) => {
+      const count = platformInfo.filter((p) => song.platformIds?.[p.key]).length;
+      return count > 0 && count < 5;
+    }).length;
+    const fullyLinkedCount = songs.filter((song) =>
+      platformInfo.every((p) => song.platformIds?.[p.key])
+    ).length;
+    return { total, linkedCount, partialCount, fullyLinkedCount };
+  }, [songs]);
+
+  if (loading) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        <div className="flex items-center justify-center py-24">
+          <Loader2 size={32} className="animate-spin text-gray-400" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-12">
+      <header className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="p-2 bg-brand-primary text-gray-900 rounded-xl shadow-lg">
+            <Link2 size={24} />
+          </div>
+          <h1 className="text-4xl font-serif font-bold text-gray-900">歌曲关联管理</h1>
+        </div>
+        <p className="text-gray-500">管理同一歌曲在不同平台的关联</p>
+      </header>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+          <p className="text-2xl font-bold text-gray-900">{stats.total}</p>
+          <p className="text-xs text-gray-500">总歌曲数</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+          <p className="text-2xl font-bold text-blue-600">{stats.linkedCount}</p>
+          <p className="text-xs text-gray-500">已关联</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+          <p className="text-2xl font-bold text-yellow-600">{stats.partialCount}</p>
+          <p className="text-xs text-gray-500">部分关联</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+          <p className="text-2xl font-bold text-green-600">{stats.fullyLinkedCount}</p>
+          <p className="text-xs text-gray-500">全部关联</p>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-[32px] border border-gray-100 shadow-sm overflow-hidden">
+        <div className="p-6 border-b border-gray-50 flex flex-col sm:flex-row gap-4">
+          <div className="relative flex-1">
+            <Search size={18} className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="搜索歌名或艺术家..."
+              className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
+            />
+          </div>
+          <div className="flex gap-3">
+            <select
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value as 'all' | 'partial' | 'unlinked')}
+              className="px-4 py-2.5 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 text-sm"
+            >
+              <option value="all">全部状态</option>
+              <option value="partial">部分关联</option>
+              <option value="unlinked">未关联</option>
+            </select>
+            <select
+              value={filterPlatform}
+              onChange={(e) => setFilterPlatform(e.target.value as Platform | 'all')}
+              className="px-4 py-2.5 rounded-xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 text-sm"
+            >
+              <option value="all">全部平台</option>
+              <option value="netease">网易云</option>
+              <option value="tencent">QQ音乐</option>
+              <option value="kugou">酷狗</option>
+              <option value="baidu">百度</option>
+              <option value="kuwo">酷我</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-50">
+                <th className="text-left text-xs font-bold text-gray-500 uppercase tracking-wider px-6 py-4">歌曲</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">网易云</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">QQ音乐</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">酷狗</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">百度</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">酷我</th>
+                <th className="text-center text-xs font-bold text-gray-500 uppercase tracking-wider px-4 py-4">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredSongs.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="text-center py-12 text-gray-400">
+                    未找到匹配的歌曲
+                  </td>
+                </tr>
+              ) : (
+                filteredSongs.map((song) => {
+                  const linkedPlatforms = platformInfo.filter((p) => song.platformIds?.[p.key]);
+                  const unlinkedPlatforms = platformInfo.filter((p) => !song.platformIds?.[p.key]);
+                  return (
+                    <tr key={song.docId} className="border-b border-gray-50 hover:bg-gray-50/50">
+                      <td className="px-6 py-4">
+                        <Link to={`/music/${song.docId}`} className="flex items-center gap-3 hover:text-brand-primary">
+                          <img
+                            src={song.cover}
+                            alt=""
+                            className="w-10 h-10 rounded-lg object-cover"
+                            referrerPolicy="no-referrer"
+                          />
+                          <div className="min-w-0">
+                            <p className="font-bold text-gray-900 truncate max-w-[200px]">{song.title}</p>
+                            <p className="text-xs text-gray-500 truncate max-w-[200px]">{song.artist}</p>
+                          </div>
+                        </Link>
+                      </td>
+                      {platformInfo.map((platform) => {
+                        const isLinked = Boolean(song.platformIds?.[platform.key]);
+                        return (
+                          <td key={platform.key} className="px-4 py-4 text-center">
+                            {isLinked ? (
+                              <a
+                                href={buildPlatformUrl(
+                                  platform.key.replace('Id', '') as Platform,
+                                  song.platformIds![platform.key]!
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={clsx(
+                                  'inline-flex items-center justify-center w-8 h-8 rounded-full text-xs font-bold transition-all hover:scale-110',
+                                  platform.bgColor,
+                                  platform.color
+                                )}
+                                title={song.platformIds![platform.key]}
+                              >
+                                ✓
+                              </a>
+                            ) : (
+                              <span className="inline-flex items-center justify-center w-8 h-8 rounded-full text-xs text-gray-300">
+                                —
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                      <td className="px-4 py-4 text-center">
+                        <div className="flex items-center justify-center gap-1">
+                          <Link
+                            to={`/music/${song.docId}`}
+                            className="p-2 text-gray-400 hover:text-brand-primary transition-colors"
+                            title="编辑"
+                          >
+                            <ExternalLink size={16} />
+                          </Link>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-50 flex items-center justify-between">
+          <p className="text-sm text-gray-500">
+            显示 {filteredSongs.length} / {songs.length} 首歌曲
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MusicLinks;


### PR DESCRIPTION
## Summary

新增歌曲跨平台关联功能，支持手动关联和自动匹配。

### 主要功能

- **编辑歌曲时关联平台 ID**：在歌曲编辑弹窗中，可手动填写其他平台的歌曲 ID
- **自动匹配搜索**：点击「匹配」按钮，在目标平台搜索相似歌曲并自动填入 ID（匹配度 ≥80% 时自动选中）
- **平台 ID 冲突检测**：如果填入的 ID 已被其他歌曲使用，提示冲突
- **导入时自动关联**：导入歌曲时，如果发现同歌曲其他平台版本，自动关联到已有歌曲
- **歌曲列表显示**：歌曲卡片上显示已关联的平台标签（可点击跳转）
- **关联管理页面**：新增 `/music/links` 页面，表格展示所有歌曲的平台关联状态

### API 变更

| 端点 | 方法 | 功能 |
|------|------|------|
| `GET /api/music/match-suggestions` | GET | 搜索跨平台匹配歌曲 |
| `PATCH /api/music/:docId` | PATCH | 编辑歌曲信息（支持平台 ID，冲突检测） |
| `POST /api/music/import` | POST | 导入歌曲（支持自动关联） |

### 新增文件

- `src/components/MatchSuggestionModal.tsx` - 跨平台匹配搜索弹窗
- `src/pages/MusicLinks.tsx` - 歌曲关联管理页面

### 文档

- 更新 `docs/server-deployment.md` 第 16.1 节