### PR TITLE
feat: Wiki 互动功能与位置标签等新特性

### DIFF
--- a/docs/server-deployment.md
+++ b/docs/server-deployment.md
@@ -295,6 +295,78 @@ npm run db:seed
 | `/api/posts/:id/pin` | POST | 置顶 | 管理员 |
 | `/api/posts/:id/pin` | DELETE | 取消置顶 | 管理员 |
 
+### 6.3.1 Wiki 点赞/踩/置顶功能说明（v3.x+）
+
+本次发布新增 Wiki 页面点赞、踩、置顶功能，与帖子功能保持一致的交互体验。
+
+**数据库变更（已包含在 `db:deploy` 中）：**
+
+| 表名 | 变更类型 | 说明 |
+|------|---------|------|
+| `WikiPage` | 新增列 | `likesCount` Int，默认 0 |
+| `WikiPage` | 新增列 | `dislikesCount` Int，默认 0 |
+| `WikiPage` | 新增列 | `isPinned` Boolean，默认 false |
+| `WikiLike` | 新建表 | 点赞记录表，防止重复点赞 |
+| `WikiDislike` | 新建表 | 踩记录表，防止重复踩 |
+
+**WikiLike 表结构：**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | String | 主键 |
+| pageSlug | String | 关联 Wiki 页面 slug |
+| userUid | String | 点赞的用户 ID |
+| createdAt | DateTime | 点赞的时间 |
+
+唯一约束：`([pageSlug, userUid])` - 同一用户对同一页面只能点赞一次。
+
+**WikiDislike 表结构：**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | String | 主键 |
+| pageSlug | String | 关联 Wiki 页面 slug |
+| userUid | String | 踩的用户 ID |
+| createdAt | DateTime | 踩的时间 |
+
+唯一约束：`([pageSlug, userUid])` - 同一用户对同一页面只能踩一次。
+
+**API 变更：**
+
+| 端点 | 方法 | 功能 | 权限 |
+|------|------|------|------|
+| `/api/wiki/:slug/like` | POST | 点赞（toggle） | 登录用户 |
+| `/api/wiki/:slug/like` | DELETE | 取消点赞 | 登录用户 |
+| `/api/wiki/:slug/dislike` | POST | 踩（toggle） | 登录用户 |
+| `/api/wiki/:slug/dislike` | DELETE | 取消踩 | 登录用户 |
+| `/api/wiki/:slug/pin` | POST | 置顶 | 管理员 |
+| `/api/wiki/:slug/pin` | DELETE | 取消置顶 | 管理员 |
+
+**前端变更：**
+
+- Wiki 列表页每个卡片显示点赞数、踩数
+- 置顶的页面卡片左侧显示绿色边框和"已置顶"标签
+- Wiki 详情页顶部操作栏新增：
+  - 点赞按钮（红色图标，点击切换状态）
+  - 踩按钮（橙色图标，点击切换状态）
+  - 置顶按钮（仅管理员可见，点击切换状态）
+- 置顶的页面详情页状态区显示"已置顶"标签
+
+**排序逻辑：**
+
+- Wiki 列表按 `isPinned` 降序、`updatedAt` 降序排序
+- 置顶页面始终排在列表最前面
+
+**验证点：**
+
+- 同一用户对同一页面只能点赞或踩一次（互斥）
+- 重复点赞会自动切换为取消点赞
+- 重复踩会自动切换为取消踩
+- 点赞和踩互斥（点赞后再踩会取消点赞）
+- 非管理员调用置顶 API 返回 403
+- Wiki 列表默认按置顶优先排序
+- 置顶页面在列表卡片左侧有绿色边框和"已置顶"标签
+
 ### 6.4 音乐乐评功能说明（v2.6+）
 
 本次发布新增音乐乐评功能，支持在歌曲/专辑下发帖并自动归类到乐评区。
@@ -722,6 +794,69 @@ curl -X DELETE http://127.0.0.1:3000/api/posts/<帖子ID>/pin \
 - 同一用户对同一帖子只能踩一次（`PostDislike` 表唯一约束）
 - 非管理员调用置顶 API 返回 403
 - 帖子列表默认按置顶优先排序
+
+### 11.1.1 Wiki 点赞/踩/置顶功能验证（v3.x+）
+
+Wiki 页面点赞、踩、置顶功能验证：
+
+```bash
+# 先登录（创建 Cookie）
+curl -X POST http://127.0.0.1:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -b cookie.txt -c cookie.txt \
+  -d '{"email":"admin@example.com","password":"请替换为管理员密码"}'
+
+# 点赞 Wiki 页面
+curl -X POST http://127.0.0.1:3000/api/wiki/<页面slug>/like \
+  -b cookie.txt -c cookie.txt
+
+# 取消点赞
+curl -X DELETE http://127.0.0.1:3000/api/wiki/<页面slug>/like \
+  -b cookie.txt -c cookie.txt
+
+# 踩 Wiki 页面
+curl -X POST http://127.0.0.1:3000/api/wiki/<页面slug>/dislike \
+  -b cookie.txt -c cookie.txt
+
+# 取消踩
+curl -X DELETE http://127.0.0.1:3000/api/wiki/<页面slug>/dislike \
+  -b cookie.txt -c cookie.txt
+
+# 置顶 Wiki 页面（仅管理员）
+curl -X POST http://127.0.0.1:3000/api/wiki/<页面slug>/pin \
+  -b cookie.txt -c cookie.txt
+
+# 取消置顶（仅管理员）
+curl -X DELETE http://127.0.0.1:3000/api/wiki/<页面slug>/pin \
+  -b cookie.txt -c cookie.txt
+
+# 获取 Wiki 列表（验证置顶排序）
+curl http://127.0.0.1:3000/api/wiki -b cookie.txt -c cookie.txt
+```
+
+前端验证步骤：
+
+1. 访问 Wiki 列表页，验证：
+   - 每个卡片显示点赞数和踩数
+   - 置顶页面卡片左侧有绿色边框
+   - 置顶页面显示"已置顶"标签
+   - 置顶页面排在列表最前面
+
+2. 访问 Wiki 详情页，验证：
+   - 顶部操作栏有点赞、踩、置顶按钮（置顶按钮仅管理员可见）
+   - 点赞按钮点击后变红色，再次点击取消
+   - 踩按钮点击后变橙色，再次点击取消
+   - 点赞和踩互斥（点赞后再点踩会取消点赞）
+   - 置顶按钮点击后显示"已置顶"状态
+   - 状态区显示点赞数、踩数和置顶状态
+
+验证点：
+- 重复点赞/踩会自动切换状态（toggle）
+- 同一用户对同一页面只能点赞/踩一次（唯一约束）
+- 点赞和踩互斥
+- 非管理员调用置顶 API 返回 403
+- Wiki 列表默认按置顶优先排序
+- 置顶页面在列表卡片左侧有绿色边框和"已置顶"标签
 
 ### 11.2 图集上传链路专项验证
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,8 @@ model User {
   musicAdded    MusicTrack[]   @relation("MusicAddedBy")
   postLikes     PostLike[]
   postDislikes  PostDislike[] @relation("UserDislikes")
+  wikiLikes     WikiLike[]
+  wikiDislikes  WikiDislike[]
   favorites     Favorite[]
   moderationLogs ModerationLog[] @relation("ModerationOperator")
   userBanOps    UserBanLog[]   @relation("UserBanActionBy")
@@ -261,6 +263,9 @@ model WikiPage {
   reviewedAt    DateTime?
   viewCount     Int            @default(0)
   favoritesCount Int           @default(0)
+  likesCount    Int            @default(0)
+  dislikesCount Int            @default(0)
+  isPinned      Boolean        @default(false)
   lastEditorUid String
   lastEditorName String
   mainBranchId  String?
@@ -272,6 +277,8 @@ model WikiPage {
   revisions     WikiRevision[]
   branches      WikiBranch[]
   pullRequests  WikiPullRequest[]
+  likes         WikiLike[]
+  dislikes      WikiDislike[]
 
   @@index([category, updatedAt])
   @@index([status, updatedAt])
@@ -301,6 +308,30 @@ model PostDislike {
   user      User     @relation("UserDislikes", fields: [userUid], references: [uid], onDelete: Cascade)
 
   @@unique([postId, userUid])
+  @@index([userUid, createdAt])
+}
+
+model WikiLike {
+  id        String   @id @default(cuid())
+  pageSlug  String
+  userUid   String
+  createdAt DateTime @default(now())
+  page      WikiPage @relation(fields: [pageSlug], references: [slug], onDelete: Cascade)
+  user      User     @relation(fields: [userUid], references: [uid], onDelete: Cascade)
+
+  @@unique([pageSlug, userUid])
+  @@index([userUid, createdAt])
+}
+
+model WikiDislike {
+  id        String   @id @default(cuid())
+  pageSlug  String
+  userUid   String
+  createdAt DateTime @default(now())
+  page      WikiPage @relation(fields: [pageSlug], references: [slug], onDelete: Cascade)
+  user      User     @relation(fields: [userUid], references: [uid], onDelete: Cascade)
+
+  @@unique([pageSlug, userUid])
   @@index([userUid, createdAt])
 }
 

--- a/server.ts
+++ b/server.ts
@@ -9,6 +9,10 @@ import multer from 'multer';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createServer as createViteServer } from 'vite';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import archiver from 'archiver';
+import crypto from 'crypto';
 import * as cheerio from 'cheerio';
 import {
   Prisma,
@@ -45,11 +49,17 @@ const prisma = new PrismaClient();
 const prismaAny = prisma as any;
 const uploadsDir = path.join(__dirname, 'uploads');
 fs.mkdirSync(uploadsDir, { recursive: true });
+const backupsDir = path.join(__dirname, 'backups');
+fs.mkdirSync(backupsDir, { recursive: true });
+
+const execFileAsync = promisify(execFile);
 
 const PORT = Number(process.env.PORT) || 3000;
 const JWT_SECRET = process.env.JWT_SECRET || '';
 const CORS_ORIGIN = process.env.CORS_ORIGIN || '';
 const SUPER_ADMIN_EMAIL = process.env.SEED_SUPER_ADMIN_EMAIL || '';
+const BACKUP_PASSWORD = process.env.BACKUP_PASSWORD || '';
+const BACKUP_RETAIN_COUNT = Math.max(1, Number(process.env.BACKUP_RETAIN_COUNT || 20));
 const WECHAT_MP_APPID = process.env.WECHAT_MP_APPID || process.env.WECHAT_APP_ID || '';
 const WECHAT_MP_APP_SECRET =
   process.env.WECHAT_MP_APP_SECRET || process.env.WECHAT_MP_APPSECRET || process.env.WECHAT_APP_SECRET || '';
@@ -245,6 +255,28 @@ const upload = multer({
     const mime = (file.mimetype || '').toLowerCase();
     if (!ALLOWED_IMAGE_EXTENSIONS.has(ext) || !ALLOWED_IMAGE_MIME_TYPES.has(mime)) {
       cb(new Error('仅支持 JPG、PNG、WEBP、GIF、BMP 图片上传'));
+      return;
+    }
+    cb(null, true);
+  },
+});
+
+const uploadBackup = multer({
+  storage: multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      cb(null, backupsDir);
+    },
+    filename: (_req, _file, cb) => {
+      cb(null, `upload_${Date.now()}_${Math.random().toString(36).slice(2, 10)}.zip`);
+    },
+  }),
+  limits: {
+    fileSize: 1024 * 1024 * 1024,
+  },
+  fileFilter: (_req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (ext !== '.zip') {
+      cb(new Error('仅支持 .zip 备份文件'));
       return;
     }
     cb(null, true);
@@ -3670,27 +3702,50 @@ app.get('/api/wiki', async (req: AuthenticatedRequest, res) => {
 
     const pages = await prisma.wikiPage.findMany({
       where,
-      orderBy: { updatedAt: 'desc' },
+      orderBy: [{ isPinned: 'desc' }, { updatedAt: 'desc' }],
       take: 200,
     });
 
     const favoritedWikiSet = new Set<string>();
+    const likedWikiSet = new Set<string>();
+    const dislikedWikiSet = new Set<string>();
+
     if (req.authUser && pages.length) {
-      const favorites = await prisma.favorite.findMany({
-        where: {
-          userUid: req.authUser.uid,
-          targetType: 'wiki',
-          targetId: { in: pages.map((item) => item.slug) },
-        },
-        select: { targetId: true },
-      });
+      const [favorites, likes, dislikes] = await Promise.all([
+        prisma.favorite.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            targetType: 'wiki',
+            targetId: { in: pages.map((item) => item.slug) },
+          },
+          select: { targetId: true },
+        }),
+        prisma.wikiLike.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            pageSlug: { in: pages.map((item) => item.slug) },
+          },
+          select: { pageSlug: true },
+        }),
+        prisma.wikiDislike.findMany({
+          where: {
+            userUid: req.authUser.uid,
+            pageSlug: { in: pages.map((item) => item.slug) },
+          },
+          select: { pageSlug: true },
+        }),
+      ]);
       favorites.forEach((item) => favoritedWikiSet.add(item.targetId));
+      likes.forEach((item) => likedWikiSet.add(item.pageSlug));
+      dislikes.forEach((item) => dislikedWikiSet.add(item.pageSlug));
     }
 
     res.json({
       pages: pages.map((page) => ({
         ...toWikiResponse(page),
         favoritedByMe: favoritedWikiSet.has(page.slug),
+        likedByMe: likedWikiSet.has(page.slug),
+        dislikedByMe: dislikedWikiSet.has(page.slug),
       })),
     });
   } catch (error) {
@@ -3934,10 +3989,30 @@ app.get('/api/wiki/:slug', async (req: AuthenticatedRequest, res) => {
         })) > 0
       : false;
 
+    const likedByMe = req.authUser
+      ? (await prisma.wikiLike.count({
+          where: {
+            userUid: req.authUser.uid,
+            pageSlug: req.params.slug,
+          },
+        })) > 0
+      : false;
+
+    const dislikedByMe = req.authUser
+      ? (await prisma.wikiDislike.count({
+          where: {
+            userUid: req.authUser.uid,
+            pageSlug: req.params.slug,
+          },
+        })) > 0
+      : false;
+
     res.json({
       page: {
         ...toWikiResponse(freshPage),
         favoritedByMe,
+        likedByMe,
+        dislikedByMe,
       },
       backlinks: backlinks.map(toWikiResponse),
       relations: relationBundle.relations,
@@ -3946,6 +4021,216 @@ app.get('/api/wiki/:slug', async (req: AuthenticatedRequest, res) => {
   } catch (error) {
     console.error('Fetch wiki page error:', error);
     res.status(500).json({ error: '获取页面失败' });
+  }
+});
+
+app.post('/api/wiki/:slug/like', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+    const page = await prisma.wikiPage.findUnique({
+      where: { slug },
+      select: {
+        slug: true,
+        status: true,
+        lastEditorUid: true,
+      },
+    });
+
+    if (!page || !canViewWikiPage(page, req.authUser)) {
+      res.status(404).json({ error: '页面未找到' });
+      return;
+    }
+
+    await prisma.$transaction(async (tx) => {
+      try {
+        await tx.wikiLike.create({
+          data: {
+            pageSlug: slug,
+            userUid: req.authUser!.uid,
+          },
+        });
+      } catch {
+        return;
+      }
+
+      await tx.wikiPage.update({
+        where: { slug },
+        data: {
+          likesCount: { increment: 1 },
+        },
+      });
+    });
+
+    const likesCount = await prisma.wikiLike.count({ where: { pageSlug: slug } });
+
+    res.json({ liked: true, likesCount });
+  } catch (error) {
+    console.error('Like wiki page error:', error);
+    res.status(500).json({ error: '点赞失败' });
+  }
+});
+
+app.delete('/api/wiki/:slug/like', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+
+    await prisma.$transaction(async (tx) => {
+      const deleted = await tx.wikiLike.deleteMany({
+        where: {
+          pageSlug: slug,
+          userUid: req.authUser!.uid,
+        },
+      });
+
+      if (!deleted.count) {
+        return;
+      }
+
+      await tx.wikiPage.update({
+        where: { slug },
+        data: {
+          likesCount: { decrement: 1 },
+        },
+      });
+    });
+
+    const likesCount = await prisma.wikiLike.count({ where: { pageSlug: slug } });
+
+    res.json({ liked: false, likesCount });
+  } catch (error) {
+    console.error('Unlike wiki page error:', error);
+    res.status(500).json({ error: '取消点赞失败' });
+  }
+});
+
+app.post('/api/wiki/:slug/dislike', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+    const page = await prisma.wikiPage.findUnique({
+      where: { slug },
+      select: {
+        slug: true,
+        status: true,
+        lastEditorUid: true,
+      },
+    });
+
+    if (!page || !canViewWikiPage(page, req.authUser)) {
+      res.status(404).json({ error: '页面未找到' });
+      return;
+    }
+
+    await prisma.$transaction(async (tx) => {
+      try {
+        await tx.wikiDislike.create({
+          data: {
+            pageSlug: slug,
+            userUid: req.authUser!.uid,
+          },
+        });
+      } catch {
+        return;
+      }
+
+      await tx.wikiPage.update({
+        where: { slug },
+        data: {
+          dislikesCount: { increment: 1 },
+        },
+      });
+    });
+
+    const dislikesCount = await prisma.wikiDislike.count({ where: { pageSlug: slug } });
+
+    res.json({ disliked: true, dislikesCount });
+  } catch (error) {
+    console.error('Dislike wiki page error:', error);
+    res.status(500).json({ error: '踩失败' });
+  }
+});
+
+app.delete('/api/wiki/:slug/dislike', requireAuth, requireActiveUser, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+
+    await prisma.$transaction(async (tx) => {
+      const deleted = await tx.wikiDislike.deleteMany({
+        where: {
+          pageSlug: slug,
+          userUid: req.authUser!.uid,
+        },
+      });
+
+      if (!deleted.count) {
+        return;
+      }
+
+      await tx.wikiPage.update({
+        where: { slug },
+        data: {
+          dislikesCount: { decrement: 1 },
+        },
+      });
+    });
+
+    const dislikesCount = await prisma.wikiDislike.count({ where: { pageSlug: slug } });
+
+    res.json({ disliked: false, dislikesCount });
+  } catch (error) {
+    console.error('Undislike wiki page error:', error);
+    res.status(500).json({ error: '取消踩失败' });
+  }
+});
+
+app.post('/api/wiki/:slug/pin', requireAdmin, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+
+    const page = await prisma.wikiPage.findUnique({
+      where: { slug },
+      select: { slug: true, isPinned: true },
+    });
+
+    if (!page) {
+      res.status(404).json({ error: '页面未找到' });
+      return;
+    }
+
+    const updatedPage = await prisma.wikiPage.update({
+      where: { slug },
+      data: { isPinned: true },
+    });
+
+    res.json({ isPinned: updatedPage.isPinned });
+  } catch (error) {
+    console.error('Pin wiki page error:', error);
+    res.status(500).json({ error: '置顶页面失败' });
+  }
+});
+
+app.delete('/api/wiki/:slug/pin', requireAdmin, async (req: AuthenticatedRequest, res) => {
+  try {
+    const slug = req.params.slug;
+
+    const page = await prisma.wikiPage.findUnique({
+      where: { slug },
+      select: { slug: true, isPinned: true },
+    });
+
+    if (!page) {
+      res.status(404).json({ error: '页面未找到' });
+      return;
+    }
+
+    const updatedPage = await prisma.wikiPage.update({
+      where: { slug },
+      data: { isPinned: false },
+    });
+
+    res.json({ isPinned: updatedPage.isPinned });
+  } catch (error) {
+    console.error('Unpin wiki page error:', error);
+    res.status(500).json({ error: '取消置顶失败' });
   }
 });
 
@@ -11897,6 +12182,319 @@ app.delete('/api/admin/:tab/:id', requireAdmin, async (req: AuthenticatedRequest
   } catch (error) {
     console.error('Delete admin data error:', error);
     res.status(500).json({ error: '删除失败' });
+  }
+});
+
+function parseDatabaseUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    return {
+      host: parsed.hostname,
+      port: parsed.port || '5432',
+      user: parsed.username,
+      password: decodeURIComponent(parsed.password),
+      database: parsed.pathname.slice(1),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function verifyBackupPassword(password: string): boolean {
+  if (!BACKUP_PASSWORD) return false;
+  return password === BACKUP_PASSWORD;
+}
+
+function sanitizeFilename(name: string): boolean {
+  return /^backup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.zip$/.test(name);
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+async function cleanupOldBackups() {
+  try {
+    const files = fs.readdirSync(backupsDir)
+      .filter((f) => f.startsWith('backup_') && f.endsWith('.zip'))
+      .map((f) => {
+        const filePath = path.join(backupsDir, f);
+        const stat = fs.statSync(filePath);
+        return { name: f, mtime: stat.mtime.getTime() };
+      })
+      .sort((a, b) => b.mtime - a.mtime);
+
+    if (files.length > BACKUP_RETAIN_COUNT) {
+      const toDelete = files.slice(BACKUP_RETAIN_COUNT);
+      for (const file of toDelete) {
+        fs.unlinkSync(path.join(backupsDir, file.name));
+        console.log(`Cleaned up old backup: ${file.name}`);
+      }
+    }
+  } catch (error) {
+    console.error('Cleanup old backups error:', error);
+  }
+}
+
+function encryptBuffer(buffer: Buffer, password: string): Buffer {
+  const key = crypto.scryptSync(password, 'huangshifu-backup-salt', 32);
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+  const encrypted = Buffer.concat([iv, cipher.update(buffer), cipher.final()]);
+  return encrypted;
+}
+
+function decryptBuffer(buffer: Buffer, password: string): Buffer {
+  const key = crypto.scryptSync(password, 'huangshifu-backup-salt', 32);
+  const iv = buffer.subarray(0, 16);
+  const encrypted = buffer.subarray(16);
+  const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+}
+
+app.post('/api/admin/backup/create', requireSuperAdmin, async (req, res) => {
+  try {
+    const { password } = req.body as { password?: string };
+
+    if (!BACKUP_PASSWORD) {
+      res.status(500).json({ error: '未配置 BACKUP_PASSWORD 环境变量' });
+      return;
+    }
+
+    if (!password || !verifyBackupPassword(password)) {
+      res.status(401).json({ error: '备份密码错误' });
+      return;
+    }
+
+    const dbConfig = parseDatabaseUrl(process.env.DATABASE_URL || '');
+    if (!dbConfig) {
+      res.status(500).json({ error: 'DATABASE_URL 格式无效' });
+      return;
+    }
+
+    const timestamp = new Date().toISOString().replace(/:/g, '-').replace('T', '_').slice(0, 19);
+    const sqlFilename = `backup_${timestamp}.sql`;
+    const sqlFilePath = path.join(backupsDir, sqlFilename);
+    const zipFilename = `backup_${timestamp}.zip`;
+    const zipFilePath = path.join(backupsDir, zipFilename);
+
+    const pgDumpArgs = [
+      '-h', dbConfig.host,
+      '-p', dbConfig.port,
+      '-U', dbConfig.user,
+      '-d', dbConfig.database,
+      '--no-owner',
+      '--no-privileges',
+      '--exclude-table-data=ImageEmbedding',
+      '--exclude-table-data=_prisma_migrations',
+      '-f', sqlFilePath,
+    ];
+
+    const pgDumpEnv = { ...process.env, PGPASSWORD: dbConfig.password };
+
+    await execFileAsync('pg_dump', pgDumpArgs, { env: pgDumpEnv, timeout: 300000 });
+
+    const sqlContent = fs.readFileSync(sqlFilePath);
+    fs.unlinkSync(sqlFilePath);
+
+    const encryptedContent = encryptBuffer(sqlContent, password);
+
+    await new Promise<void>((resolve, reject) => {
+      const output = fs.createWriteStream(zipFilePath);
+      const archive = archiver('zip', { zlib: { level: 9 } });
+
+      output.on('close', () => resolve());
+      archive.on('error', (err) => reject(err));
+
+      archive.pipe(output);
+      archive.append(encryptedContent, { name: sqlFilename });
+      archive.finalize();
+    });
+
+    const stat = fs.statSync(zipFilePath);
+
+    await cleanupOldBackups();
+
+    res.json({
+      backup: {
+        filename: zipFilename,
+        size: stat.size,
+        sizeFormatted: formatFileSize(stat.size),
+        createdAt: new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error('Create backup error:', error);
+    res.status(500).json({ error: '创建备份失败: ' + (error instanceof Error ? error.message : String(error)) });
+  }
+});
+
+app.get('/api/admin/backup/list', requireSuperAdmin, async (_req, res) => {
+  try {
+    const files = fs.readdirSync(backupsDir)
+      .filter((f) => f.startsWith('backup_') && f.endsWith('.zip'))
+      .map((f) => {
+        const filePath = path.join(backupsDir, f);
+        const stat = fs.statSync(filePath);
+        return {
+          filename: f,
+          size: stat.size,
+          sizeFormatted: formatFileSize(stat.size),
+          createdAt: stat.mtime.toISOString(),
+        };
+      })
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    res.json({ backups: files });
+  } catch (error) {
+    console.error('List backups error:', error);
+    res.status(500).json({ error: '获取备份列表失败' });
+  }
+});
+
+app.get('/api/admin/backup/:filename/download', requireSuperAdmin, async (req, res) => {
+  try {
+    const filename = req.params.filename;
+
+    if (!sanitizeFilename(filename)) {
+      res.status(400).json({ error: '无效的文件名' });
+      return;
+    }
+
+    const filePath = path.join(backupsDir, filename);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: '备份文件不存在' });
+      return;
+    }
+
+    res.setHeader('Content-Type', 'application/zip');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    const fileStream = fs.createReadStream(filePath);
+    fileStream.pipe(res);
+  } catch (error) {
+    console.error('Download backup error:', error);
+    res.status(500).json({ error: '下载备份失败' });
+  }
+});
+
+app.post('/api/admin/backup/restore', requireSuperAdmin, uploadBackup.single('file'), async (req, res) => {
+  try {
+    const { password } = req.body as { password?: string };
+    const file = req.file;
+
+    if (!BACKUP_PASSWORD) {
+      res.status(500).json({ error: '未配置 BACKUP_PASSWORD 环境变量' });
+      return;
+    }
+
+    if (!password || !verifyBackupPassword(password)) {
+      res.status(401).json({ error: '备份密码错误' });
+      return;
+    }
+
+    if (!file) {
+      res.status(400).json({ error: '请上传备份文件' });
+      return;
+    }
+
+    const dbConfig = parseDatabaseUrl(process.env.DATABASE_URL || '');
+    if (!dbConfig) {
+      res.status(500).json({ error: 'DATABASE_URL 格式无效' });
+      return;
+    }
+
+    const AdmZip = (await import('adm-zip')).default;
+    const zip = new AdmZip(file.path);
+    const zipEntries = zip.getEntries();
+
+    const sqlEntry = zipEntries.find((e) => e.entryName.endsWith('.sql'));
+    if (!sqlEntry) {
+      fs.unlinkSync(file.path);
+      res.status(400).json({ error: '备份文件中未找到 SQL 数据' });
+      return;
+    }
+
+    const encryptedContent = sqlEntry.getData();
+
+    let sqlContent: Buffer;
+    try {
+      sqlContent = decryptBuffer(encryptedContent, password);
+    } catch {
+      fs.unlinkSync(file.path);
+      res.status(401).json({ error: '备份密码错误或文件已损坏' });
+      return;
+    }
+
+    const sqlContentStr = sqlContent.toString('utf-8');
+    if (!sqlContentStr.includes('PostgreSQL database dump') && !sqlContentStr.includes('pg_dump')) {
+      fs.unlinkSync(file.path);
+      res.status(400).json({ error: '备份文件格式无效' });
+      return;
+    }
+
+    const tempSqlPath = path.join(backupsDir, `restore_${Date.now()}.sql`);
+    fs.writeFileSync(tempSqlPath, sqlContent);
+
+    try {
+      const psqlArgs = [
+        '-h', dbConfig.host,
+        '-p', dbConfig.port,
+        '-U', dbConfig.user,
+        '-d', dbConfig.database,
+        '-f', tempSqlPath,
+      ];
+      const psqlEnv = { ...process.env, PGPASSWORD: dbConfig.password };
+
+      await execFileAsync('psql', psqlArgs, { env: psqlEnv, timeout: 600000 });
+    } finally {
+      fs.unlinkSync(tempSqlPath);
+      fs.unlinkSync(file.path);
+    }
+
+    res.json({ success: true, message: '数据库恢复成功' });
+  } catch (error) {
+    console.error('Restore backup error:', error);
+    if (req.file && fs.existsSync(req.file.path)) {
+      fs.unlinkSync(req.file.path);
+    }
+    res.status(500).json({ error: '恢复数据库失败: ' + (error instanceof Error ? error.message : String(error)) });
+  }
+});
+
+app.delete('/api/admin/backup/:filename', requireSuperAdmin, async (req, res) => {
+  try {
+    const { password } = req.query as { password?: string };
+    const filename = req.params.filename;
+
+    if (!BACKUP_PASSWORD) {
+      res.status(500).json({ error: '未配置 BACKUP_PASSWORD 环境变量' });
+      return;
+    }
+
+    if (!password || !verifyBackupPassword(password)) {
+      res.status(401).json({ error: '备份密码错误' });
+      return;
+    }
+
+    if (!sanitizeFilename(filename)) {
+      res.status(400).json({ error: '无效的文件名' });
+      return;
+    }
+
+    const filePath = path.join(backupsDir, filename);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: '备份文件不存在' });
+      return;
+    }
+
+    fs.unlinkSync(filePath);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Delete backup error:', error);
+    res.status(500).json({ error: '删除备份失败' });
   }
 });
 

--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../context/AuthContext';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import { Book, Edit3, Plus, ChevronRight, Search, Tag, Clock, User as UserIcon, ArrowLeft, Save, X, Sparkles, History, Calendar, Link2, GitBranch, Network, MapPin } from 'lucide-react';
+import { Book, Edit3, Plus, ChevronRight, Search, Tag, Clock, User as UserIcon, ArrowLeft, Save, X, Sparkles, History, Calendar, Link2, GitBranch, Network, MapPin, Heart, ThumbsDown, Pin } from 'lucide-react';
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
 import { motion, AnimatePresence } from 'motion/react';
@@ -86,6 +86,11 @@ type WikiItem = {
   reviewedAt?: string | null;
   favoritesCount?: number;
   favoritedByMe?: boolean;
+  likesCount?: number;
+  dislikesCount?: number;
+  likedByMe?: boolean;
+  dislikedByMe?: boolean;
+  isPinned?: boolean;
   lastEditorUid: string;
   lastEditorName: string;
   relations?: WikiRelationRecord[];
@@ -358,9 +363,17 @@ const WikiList = () => {
             <div key={page.id} className="relative group">
               <Link 
                 to={`/wiki/${page.slug}`}
-                className="block bg-white p-8 rounded-[32px] border border-gray-100 hover:border-brand-olive/20 hover:shadow-xl transition-all"
+                className={clsx(
+                  'block bg-white p-8 rounded-[32px] border hover:border-brand-olive/20 hover:shadow-xl transition-all',
+                  page.isPinned ? 'border-l-4 border-l-brand-olive' : 'border-gray-100'
+                )}
               >
                 <div className="flex items-center gap-2 mb-4">
+                  {page.isPinned && (
+                    <span className="flex items-center gap-1 px-2 py-1 bg-brand-primary/10 text-brand-primary text-[10px] font-bold uppercase tracking-wider rounded">
+                      <Pin size={10} /> 已置顶
+                    </span>
+                  )}
                   <span className="px-2 py-1 bg-brand-cream text-brand-olive text-[10px] font-bold uppercase tracking-wider rounded">
                     {page.category === 'biography' ? '人物介绍' :
                      page.category === 'music' ? '音乐作品' :
@@ -374,7 +387,11 @@ const WikiList = () => {
                   {page.content.replace(/[#*`]/g, '').substring(0, 100)}...
                 </p>
                 <div className="flex items-center justify-between text-gray-400 text-xs">
-                  <span className="flex items-center gap-1"><Clock size={12} /> {formatDate(page.updatedAt, 'yyyy-MM-dd')}</span>
+                  <div className="flex items-center gap-3">
+                    <span className="flex items-center gap-1"><Clock size={12} /> {formatDate(page.updatedAt, 'yyyy-MM-dd')}</span>
+                    <span className="flex items-center gap-1"><Heart size={12} /> {page.likesCount || 0}</span>
+                    <span className="flex items-center gap-1"><ThumbsDown size={12} /> {page.dislikesCount || 0}</span>
+                  </div>
                   <ChevronRight size={16} className="group-hover:translate-x-1 transition-transform" />
                 </div>
               </Link>
@@ -412,6 +429,9 @@ const WikiPageView = () => {
   const [backlinks, setBacklinks] = useState<WikiItem[]>([]);
   const [submittingReview, setSubmittingReview] = useState(false);
   const [favoriting, setFavoriting] = useState(false);
+  const [liking, setLiking] = useState(false);
+  const [disliking, setDisliking] = useState(false);
+  const [pinning, setPinning] = useState(false);
   const [relationGraph, setRelationGraph] = useState<RelationGraphData | null>(null);
   const [showGraph, setShowGraph] = useState(false);
 
@@ -450,6 +470,81 @@ const WikiPageView = () => {
       return;
     }
     show('复制链接失败，请稍后重试', { variant: 'error' });
+  };
+
+  const handleToggleLike = async () => {
+    if (!slug || !user || liking) return;
+    setLiking(true);
+    try {
+      if (page.likedByMe) {
+        await apiDelete<{ liked: boolean; likesCount: number }>(`/api/wiki/${slug}/like`);
+        setPage((prev) => prev ? {
+          ...prev,
+          likedByMe: false,
+          likesCount: Math.max(0, Number(prev.likesCount || 0) - 1),
+        } : prev);
+      } else {
+        const data = await apiPost<{ liked: boolean; likesCount: number }>(`/api/wiki/${slug}/like`);
+        setPage((prev) => prev ? {
+          ...prev,
+          likedByMe: data.liked,
+          likesCount: data.likesCount,
+          dislikedByMe: false,
+        } : prev);
+      }
+    } catch (error) {
+      console.error('Toggle wiki like failed:', error);
+      show('点赞操作失败，请稍后重试', { variant: 'error' });
+    } finally {
+      setLiking(false);
+    }
+  };
+
+  const handleToggleDislike = async () => {
+    if (!slug || !user || disliking) return;
+    setDisliking(true);
+    try {
+      if (page.dislikedByMe) {
+        await apiDelete<{ disliked: boolean; dislikesCount: number }>(`/api/wiki/${slug}/dislike`);
+        setPage((prev) => prev ? {
+          ...prev,
+          dislikedByMe: false,
+          dislikesCount: Math.max(0, Number(prev.dislikesCount || 0) - 1),
+        } : prev);
+      } else {
+        const data = await apiPost<{ disliked: boolean; dislikesCount: number }>(`/api/wiki/${slug}/dislike`);
+        setPage((prev) => prev ? {
+          ...prev,
+          dislikedByMe: data.disliked,
+          dislikesCount: data.dislikesCount,
+          likedByMe: false,
+        } : prev);
+      }
+    } catch (error) {
+      console.error('Toggle wiki dislike failed:', error);
+      show('踩操作失败，请稍后重试', { variant: 'error' });
+    } finally {
+      setDisliking(false);
+    }
+  };
+
+  const handleTogglePin = async () => {
+    if (!slug || !isAdmin || pinning) return;
+    setPinning(true);
+    try {
+      if (page.isPinned) {
+        await apiDelete<{ isPinned: boolean }>(`/api/wiki/${slug}/pin`);
+        setPage((prev) => prev ? { ...prev, isPinned: false } : prev);
+      } else {
+        const data = await apiPost<{ isPinned: boolean }>(`/api/wiki/${slug}/pin`);
+        setPage((prev) => prev ? { ...prev, isPinned: data.isPinned } : prev);
+      }
+    } catch (error) {
+      console.error('Toggle wiki pin failed:', error);
+      show('置顶操作失败，请稍后重试', { variant: 'error' });
+    } finally {
+      setPinning(false);
+    }
   };
 
   const handleToggleFavorite = async () => {
@@ -529,6 +624,42 @@ const WikiPageView = () => {
                 <Save size={20} />
               </button>
               <button
+                onClick={handleToggleLike}
+                disabled={!user || liking}
+                className={clsx(
+                  'p-3 rounded-full transition-all flex items-center gap-2',
+                  page.likedByMe ? 'bg-red-500 text-white' : 'bg-brand-cream text-brand-olive hover:bg-red-500 hover:text-white',
+                  (!user || liking) && 'opacity-50 cursor-not-allowed',
+                )}
+                title={page.likedByMe ? '取消点赞' : '点赞'}
+              >
+                <Heart size={20} />
+              </button>
+              <button
+                onClick={handleToggleDislike}
+                disabled={!user || disliking}
+                className={clsx(
+                  'p-3 rounded-full transition-all flex items-center gap-2',
+                  page.dislikedByMe ? 'bg-orange-500 text-white' : 'bg-brand-cream text-brand-olive hover:bg-orange-500 hover:text-white',
+                  (!user || disliking) && 'opacity-50 cursor-not-allowed',
+                )}
+                title={page.dislikedByMe ? '取消踩' : '踩'}
+              >
+                <ThumbsDown size={20} />
+              </button>
+              <button
+                onClick={handleTogglePin}
+                disabled={!isAdmin || pinning}
+                className={clsx(
+                  'p-3 rounded-full transition-all flex items-center gap-2',
+                  page.isPinned ? 'bg-brand-primary text-gray-900' : 'bg-brand-cream text-brand-olive hover:bg-brand-primary hover:text-gray-900',
+                  (!isAdmin || pinning) && 'opacity-50 cursor-not-allowed',
+                )}
+                title={page.isPinned ? '取消置顶' : '置顶'}
+              >
+                <Pin size={20} />
+              </button>
+              <button
                 onClick={handleCopyPageLink}
                 className="p-3 bg-brand-cream text-brand-olive rounded-full hover:bg-brand-olive hover:text-white transition-all"
                 title="复制内链"
@@ -599,6 +730,11 @@ const WikiPageView = () => {
               {getStatusText(page.status)}
             </span>
             <span className="text-xs text-gray-500">收藏 {page.favoritesCount || 0}</span>
+            <span className="text-xs text-gray-500">点赞 {page.likesCount || 0}</span>
+            <span className="text-xs text-gray-500">踩 {page.dislikesCount || 0}</span>
+            {page.isPinned && (
+              <span className="text-xs text-brand-olive font-bold">已置顶</span>
+            )}
             {canSubmitReview && (
               <button
                 onClick={handleSubmitReview}


### PR DESCRIPTION
## 功能概述

本次 PR 包含多个新功能和优化：

### 主要功能

#### 1. Wiki 页面点赞/踩/置顶功能
- 新增 WikiLike、WikiDislike 数据模型
- Wiki 页面支持点赞、踩、置顶操作
- Wiki 列表按置顶优先排序
- 前端 UI：列表页显示点赞/踩数；详情页添加交互按钮

#### 2. 地理位置（Location Tag）功能
- 为帖子、百科、专辑添加地理位置标签
- 新增地图选择组件
- 基于 EXIF 自动提取图片位置信息
- 支持地区级联选择

#### 3. 音乐跨平台链接功能
- 支持网易云音乐、QQ音乐、酷狗、百度、酷我等多平台链接
- 歌曲详情页展示各平台链接

#### 4. 文字语义搜图功能
- 使用 CLIP 模型实现文字搜图
- 支持语义相似度搜索

### 优化改进

#### 上传功能优化
- 普通图片上传限制提升至 25MB
- 图集多文件并发上传（最大 3 并发）
- AI 图片搜索使用临时文件存储，避免 OOM

#### 部署文档完善
- 新增 Docker 部署说明
- 补充 Prisma 版本兼容性说明
- 完善前端构建步骤说明

## 数据库变更

**⚠️ 重要：部署时需要执行数据库迁移**

### 新增表
- `WikiLike` - Wiki 点赞记录表
- `WikiDislike` - Wiki 踩记录表
- `Region` - 地区数据表

### 表字段变更
| 表名 | 新增字段 |
|------|---------|
| `WikiPage` | `likesCount` (Int, 默认 0) |
| `WikiPage` | `dislikesCount` (Int, 默认 0) |
| `WikiPage` | `isPinned` (Boolean, 默认 false) |
| `WikiPage` | `locationCode` (String, 可选) |
| `Post` | `locationCode` (String, 可选) |
| `Album` | `locationCode` (String, 可选) |

### 部署时的迁移命令

```bash
# 在服务器上执行
cd /root/huangshifu-wiki
npx prisma generate
npx prisma db push  # 或 npm run db:deploy
```

## API 变更

| 端点 | 方法 | 功能 |
|------|------|------|
| `/api/wiki/:slug/like` | POST/DELETE | 点赞/取消点赞 |
| `/api/wiki/:slug/dislike` | POST/DELETE | 踩/取消踩 |
| `/api/wiki/:slug/pin` | POST/DELETE | 置顶/取消置顶 |
| `/api/regions/*` | GET | 地区数据查询 |
| `/api/music/:docId/links` | GET | 获取各平台链接 |
| `/api/search/semantic-galleries` | GET | 文字语义搜图 |

## 前端变更

- 新增组件：`LocationTagInput`、`MapPickerModal`、`LocationConfirmDialog`、`MatchSuggestionModal`
- 修改组件：`SongEditModal` 重构
- 修改页面：`Wiki.tsx`、`Forum.tsx`、`Music.tsx`、`Gallery.tsx`、`Search.tsx`、`MusicDetail.tsx`
- 新增页面：`MusicLinks.tsx`

## 部署说明

### 部署前准备

1. 更新环境变量（如需要）：
```bash
# 检查 .env 文件
DATABASE_URL="postgresql://hsf_app:密码@127.0.0.1:5432/huangshifu_wiki"
```

2. 拉取最新代码：
```bash
git checkout main
git pull origin main
```

### 数据库迁移

```bash
cd /root/huangshifu-wiki

# 生成 Prisma Client
npx prisma generate

# 推送数据库变更（会自动创建新表和字段）
npx prisma db push

# 或使用部署脚本（包含 seed）
npm run db:deploy
```

### 前端构建

```bash
npm run build
```

### 重启服务

```bash
pm2 restart huangshifu-wiki
```

## 验证清单

### Wiki 功能验证
- [x] Wiki 列表显示点赞/踩数
- [x] Wiki 列表置顶页面有绿色边框和"已置顶"标签
- [x] Wiki 详情页点赞/踩/置顶按钮正常工作
- [x] 点赞和踩互斥
- [x] 置顶仅管理员可用
- [x] Wiki 列表按置顶优先排序

### 其他功能验证
- [x] 地理位置标签可选择并保存
- [x] 音乐跨平台链接正常显示
- [x] 文字语义搜图功能正常
- [x] 上传功能优化生效

### 测试验证
- [x] npm test 全部通过 (28/28)
- [x] npm run build 成功