### PR TITLE
fix: add Content-Security-Policy header for Amap JS API

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -47,6 +47,16 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 app.set('trust proxy', 1);
+
+// Content Security Policy - Allow loading Amap JS API
+app.use((req: Request, res: Response, next: NextFunction) => {
+  res.setHeader(
+    'Content-Security-Policy',
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: https://*.amap.com https://*.gaode.com blob:; style-src 'self' 'unsafe-inline';"
+  );
+  next();
+});
+
 const prisma = new PrismaClient();
 const prismaAny = prisma as any;
 const uploadsDir = path.join(__dirname, 'uploads');


### PR DESCRIPTION
Allow loading 高德地图 JS API by adding CSP header:

- script-src: allows webapi.amap.com
- connect-src: allows restapi.amap.com and webapi.amap.com  
- img-src: allows *.amap.com and *.gaode.com
- style-src: allows unsafe-inline for Vite compatibility