### PR TITLE
fix: 统一 vite.config.ts 和 server.ts 的 img-src CSP 配置

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         server.middlewares.use((req, res, next) => {
           res.setHeader(
             'Content-Security-Policy',
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://p1.music.126.net http://p2.music.126.net http://p3.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
           );
           next();
         });


### PR DESCRIPTION
## Summary
- 修复开发环境下 CSP `img-src` 与生产环境不一致的问题
- 将 `http://p1/p2/p3.music.126.net` 改为 `http://*.music.126.net` 通配符，与 server.ts 保持一致