### PR TITLE
fix: 使用通配符 *.music.126.net 匹配所有网易云CDN域名

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -12570,7 +12570,7 @@ async function startServer() {
   app.use((_req, res, next) => {
     res.setHeader(
       'Content-Security-Policy',
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://p1.music.126.net http://p2.music.126.net http://p3.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
     );
     next();
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         server.middlewares.use((req, res, next) => {
           res.setHeader(
             'Content-Security-Policy',
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://p1.music.126.net http://p2.music.126.net http://p3.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
           );
           next();
         });


### PR DESCRIPTION
## Summary
- 将 `http://p1.music.126.net http://p2.music.126.net http://p3.music.126.net` 改为 `http://*.music.126.net` 通配符
- 修复 `vite.config.ts` 和 `server.ts` 生产环境 CSP 配置不一致的问题
- 统一使用通配符匹配，避免网易云音乐 CDN 动态切换域名导致图片加载失败