### PR TITLE
fix: 修复CSP中间件顺序并添加https域名支持

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -12553,6 +12553,14 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
 });
 
 async function startServer() {
+  app.use((_req, res, next) => {
+    res.setHeader(
+      'Content-Security-Policy',
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
+    );
+    next();
+  });
+
   if (process.env.NODE_ENV !== 'production') {
     const vite = await createViteServer({
       server: { middlewareMode: true },
@@ -12566,14 +12574,6 @@ async function startServer() {
       res.sendFile(path.join(distPath, 'index.html'));
     });
   }
-
-  app.use((_req, res, next) => {
-    res.setHeader(
-      'Content-Security-Policy',
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
-    );
-    next();
-  });
 
   app.listen(PORT, '0.0.0.0', () => {
     console.log(`Server running on http://localhost:${PORT}`);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         server.middlewares.use((req, res, next) => {
           res.setHeader(
             'Content-Security-Policy',
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://webapi.amap.com; connect-src 'self' https://restapi.amap.com https://webapi.amap.com; img-src 'self' data: blob: https://*.amap.com https://*.gaode.com http://*.music.126.net https://*.music.126.net https://picsum.photos; style-src 'self' 'unsafe-inline';"
           );
           next();
         });


### PR DESCRIPTION
## Summary
- **修复CSP中间件顺序**：将CSP中间件移到 `express.static` 之前，确保静态文件请求也能正确设置CSP头（之前 `res.sendFile` 直接结束请求导致CSP中间件永远不会执行）
- **添加 `https://*.music.126.net`**：浏览器会将 HTTP 图片 URL 自动升级为 HTTPS，但原 CSP 不允许 HTTPS 域名
- 统一 `vite.config.ts` 和 `server.ts` 两处的 img-src 配置

## 根因
1. CSP 中间件被放在 `express.static` 和 `app.get('*')` 之后
2. `res.sendFile()` 不会调用 `next()`，导致后续中间件（包括CSP）永远不会被执行
3. 浏览器自动把 `http://p2.music.126.net` 升级成 `https://`，但 CSP 只有 `http://*.music.126.net`