### PR TITLE
fix: 修复百科页面移动端按钮超出显示空间的问题

### DIFF
--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -675,9 +675,9 @@ const WikiPageView = () => {
             <span className="text-gray-300">/</span>
             <span className="text-gray-400 text-sm flex items-center gap-1"><Clock size={14} /> 最后更新: {formatDate(page.updatedAt, 'yyyy-MM-dd HH:mm')}</span>
           </div>
-          <div className="flex justify-between items-start gap-4">
-            <h1 className="text-5xl sm:text-6xl font-serif font-bold text-brand-olive leading-tight">{page.title}</h1>
-            <div className="flex gap-2">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <h1 className="min-w-0 flex-1 text-5xl sm:text-6xl font-serif font-bold text-brand-olive leading-tight">{page.title}</h1>
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
               <button
                 onClick={handleToggleFavorite}
                 disabled={!user || favoriting}


### PR DESCRIPTION
## 概要
- 调整百科详情页头部布局，在小屏幕下改为上下排布，在较大屏幕下保持标题与操作区分栏显示
- 让操作按钮区域支持自动换行，避免移动端宽度不足时按钮被挤出可视区域
- 不改动按钮功能、顺序和文案，仅修复布局问题，并已通过 `npm run lint` 与 `npm run build` 验证