### PR TITLE
fix: 优化移动端图标按钮显示

### DIFF
--- a/src/components/ViewModeSelector.tsx
+++ b/src/components/ViewModeSelector.tsx
@@ -19,6 +19,7 @@ const VIEW_MODE_ICONS: Record<ViewMode, React.ReactNode> = {
 
 export const ViewModeSelector: React.FC<ViewModeSelectorProps> = ({ value, onChange, size = 'md' }) => {
   const modes: ViewMode[] = ['large', 'medium', 'small', 'list'];
+  const showLabels = size === 'md';
 
   return (
     <div className={clsx(
@@ -29,6 +30,7 @@ export const ViewModeSelector: React.FC<ViewModeSelectorProps> = ({ value, onCha
         <button
           key={mode}
           onClick={() => onChange(mode)}
+          aria-label={VIEW_MODE_LABELS[mode]}
           className={clsx(
             'rounded-full transition-all inline-flex items-center gap-1.5 font-medium',
             size === 'sm' ? 'px-2.5 py-1.5 text-xs' : 'px-3 py-2 text-sm',
@@ -39,7 +41,7 @@ export const ViewModeSelector: React.FC<ViewModeSelectorProps> = ({ value, onCha
           title={VIEW_MODE_LABELS[mode]}
         >
           {VIEW_MODE_ICONS[mode]}
-          {size === 'md' && <span>{VIEW_MODE_LABELS[mode]}</span>}
+          {showLabels && <span className="hidden sm:inline">{VIEW_MODE_LABELS[mode]}</span>}
         </button>
       ))}
     </div>

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -442,13 +442,14 @@ const Music = () => {
                 setIsBatchMode(!isBatchMode);
                 setSelectedSongs(new Set());
               }}
+              aria-label={isBatchMode ? '退出批量' : '批量管理'}
               className={clsx(
                 "px-6 py-4 rounded-full font-bold transition-all flex items-center gap-2 shadow-xl",
                 isBatchMode ? "bg-brand-primary text-gray-900" : "bg-white text-gray-500 border border-gray-100"
               )}
             >
               <List size={20} />
-              {isBatchMode ? '退出批量' : '批量管理'}
+              <span className="hidden sm:inline">{isBatchMode ? '退出批量' : '批量管理'}</span>
             </button>
             <button
               onClick={() => {
@@ -458,10 +459,11 @@ const Music = () => {
                 }
                 setIsImportModalOpen(true);
               }}
+              aria-label="链接导入"
               className="px-8 py-4 bg-brand-primary text-gray-900 rounded-full font-bold hover:scale-105 transition-all flex items-center gap-2 shadow-xl"
             >
               <Search size={20} />
-              链接导入
+              <span className="hidden sm:inline">链接导入</span>
             </button>
             <button 
               onClick={() => {
@@ -471,17 +473,19 @@ const Music = () => {
                 }
                 setIsAdding(!isAdding);
               }}
+              aria-label={isAdding ? '取消添加' : '添加音乐'}
               className="px-8 py-4 bg-gray-900 text-white rounded-full font-bold hover:scale-105 transition-all flex items-center gap-2 shadow-xl"
             >
               {isAdding ? <X size={20} /> : <Plus size={20} />}
-              {isAdding ? '取消添加' : '添加音乐'}
+              <span className="hidden sm:inline">{isAdding ? '取消添加' : '添加音乐'}</span>
             </button>
             <Link
               to="/music/links"
+              aria-label="关联管理"
               className="px-8 py-4 bg-white text-gray-900 border border-gray-200 rounded-full font-bold hover:scale-105 transition-all flex items-center gap-2 shadow-xl"
             >
               <Link2 size={20} />
-              关联管理
+              <span className="hidden sm:inline">关联管理</span>
             </Link>
           </div>
         )}

--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -365,7 +365,8 @@ const WikiList = () => {
         <div className="flex items-center gap-4">
           <ViewModeSelector value={viewMode} onChange={setViewMode} />
           <Link to="/wiki/timeline" className="px-6 py-3 bg-brand-cream text-brand-olive rounded-full font-medium hover:bg-brand-olive hover:text-white transition-all flex items-center gap-2 shadow-sm">
-            <Calendar size={18} /> 时间轴视图
+            <Calendar size={18} />
+            <span className="hidden sm:inline">时间轴视图</span>
           </Link>
           {user && !isBanned && (
             <Link to="/wiki/new" className="px-6 py-3 bg-brand-olive text-white rounded-full font-medium hover:bg-brand-olive/90 transition-all flex items-center gap-2 shadow-md">


### PR DESCRIPTION
## Summary
- 将百科页视图切换与时间轴入口改为移动端仅显示图标，避免窄屏下中文标签被挤成竖排
- 将音乐馆管理入口按钮改为移动端仅显示图标，并补充 `aria-label` 保持可访问性
- 已验证 `npm run lint`、`npm test`、`npm run build` 全部通过