### PR TITLE
fix: 对齐歌曲与专辑封面上传响应结构

### DIFF
--- a/src/components/AlbumCoverManager.tsx
+++ b/src/components/AlbumCoverManager.tsx
@@ -80,10 +80,10 @@ export const AlbumCoverManager = ({ albumDocId, currentCover, onCoverUpdated }: 
         throw new Error((data as { error?: string })?.error || '上传失败');
       }
 
-      const uploadResult = await response.json() as { asset: { id: string; url: string } };
+      const uploadResult = await response.json() as { file: { assetId: string; url: string } };
 
       await apiPost(`/api/albums/${albumDocId}/covers`, {
-        assetId: uploadResult.asset.id,
+        assetId: uploadResult.file.assetId,
       });
 
       show('封面上传成功');

--- a/src/components/SongCoverManager.tsx
+++ b/src/components/SongCoverManager.tsx
@@ -80,10 +80,10 @@ export const SongCoverManager = ({ songDocId, currentCover, onCoverUpdated }: So
         throw new Error((data as { error?: string })?.error || '上传失败');
       }
 
-      const uploadResult = await response.json() as { asset: { id: string; url: string } };
+      const uploadResult = await response.json() as { file: { assetId: string; url: string } };
 
       await apiPost(`/api/music/${songDocId}/covers`, {
-        assetId: uploadResult.asset.id,
+        assetId: uploadResult.file.assetId,
       });
 
       show('封面上传成功');


### PR DESCRIPTION
Closes #48

## Summary
- 将歌曲和专辑封面管理组件改为读取 `/api/uploads` 返回的 `file.assetId`
- 修复上传成功后无法继续创建封面记录的问题

## Testing
- npm run lint
- npm test
- npm run build