### PR TITLE
feat: 为歌曲增加 Markdown 描述字段

### DIFF
--- a/prisma/migrations/20260331104000_add_music_track_description/migration.sql
+++ b/prisma/migrations/20260331104000_add_music_track_description/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "MusicTrack" ADD COLUMN "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -609,6 +609,7 @@ model MusicTrack {
   cover     String   @default("")
   audioUrl  String   @default("")
   lyric     String?
+  description String?
   primaryPlatform    MusicPlatform   @default(netease)
   enabledPlatform    MusicPlatform?
   neteaseId          String?

--- a/server.ts
+++ b/server.ts
@@ -179,6 +179,7 @@ type MusicTrackWithRelations = {
   cover: string;
   audioUrl: string;
   lyric: string | null;
+  description: string | null;
   primaryPlatform: MusicPlatform;
   enabledPlatform: MusicPlatform | null;
   neteaseId: string | null;
@@ -1298,6 +1299,7 @@ function toSongResponse(song: MusicTrackWithRelations, options?: { favoritedByMe
     cover: coverUrl,
     audioUrl: song.audioUrl,
     lyric: song.lyric,
+    description: song.description,
     primaryPlatform: song.primaryPlatform,
     enabledPlatform: song.enabledPlatform,
     platformIds: {
@@ -9158,6 +9160,7 @@ app.patch('/api/music/:docId', requireAdmin, async (req, res) => {
     if (typeof body.cover === 'string') updateData.cover = body.cover.trim();
     if (typeof body.audioUrl === 'string') updateData.audioUrl = body.audioUrl.trim();
     if (typeof body.lyric === 'string' || body.lyric === null) updateData.lyric = body.lyric;
+    if (typeof body.description === 'string' || body.description === null) updateData.description = body.description;
 
     const primaryPlatform = parseMusicPlatform(body.primaryPlatform);
     if (primaryPlatform) updateData.primaryPlatform = primaryPlatform;

--- a/src/components/SongEditModal.tsx
+++ b/src/components/SongEditModal.tsx
@@ -20,6 +20,7 @@ type SongFormData = {
   artist: string;
   album: string;
   lyric?: string | null;
+  description?: string | null;
 };
 
 type SongItem = {
@@ -31,6 +32,7 @@ type SongItem = {
   cover: string;
   audioUrl: string;
   lyric?: string | null;
+  description?: string | null;
   primaryPlatform?: Platform | null;
   favoritedByMe?: boolean;
   platformIds?: PlatformIds;
@@ -57,6 +59,7 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
     artist: song.artist || '',
     album: song.album || '',
     lyric: song.lyric || '',
+    description: song.description || '',
   });
   const [platformIds, setPlatformIds] = useState<PlatformIds>({
     neteaseId: song.platformIds?.neteaseId || '',
@@ -77,6 +80,7 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
         artist: song.artist || '',
         album: song.album || '',
         lyric: song.lyric || '',
+        description: song.description || '',
       });
       setPlatformIds({
         neteaseId: song.platformIds?.neteaseId || '',
@@ -110,6 +114,7 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
         artist: formData.artist.trim(),
         album: formData.album.trim(),
         lyric: formData.lyric?.trim() || null,
+        description: formData.description?.trim() || null,
         neteaseId: platformIds.neteaseId || null,
         tencentId: platformIds.tencentId || null,
         kugouId: platformIds.kugouId || null,
@@ -190,6 +195,17 @@ export const SongEditModal = ({ open, onClose, onSuccess, song }: SongEditModalP
                 onChange={(e) => setFormData((prev) => ({ ...prev, album: e.target.value }))}
                 placeholder="所属专辑（可选）"
                 className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-semibold text-gray-700">描述 (Markdown)</label>
+              <textarea
+                value={formData.description || ''}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+                placeholder="创作背景、作者的话或其他补充说明（可选）"
+                rows={5}
+                className="w-full px-4 py-3 rounded-2xl border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/25 resize-none text-sm"
               />
             </div>
 

--- a/src/pages/MusicDetail.tsx
+++ b/src/pages/MusicDetail.tsx
@@ -3,6 +3,8 @@ import { Link, useParams } from 'react-router-dom';
 import { ArrowLeft, Clock, ExternalLink, Heart, Link2, MessageSquare, Play } from 'lucide-react';
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 import { apiDelete, apiGet, apiPost } from '../lib/apiClient';
 import { useAuth } from '../context/AuthContext';
@@ -29,6 +31,7 @@ type SongItem = {
   cover: string;
   audioUrl: string;
   lyric?: string | null;
+  description?: string | null;
   primaryPlatform?: 'netease' | 'tencent' | 'kugou' | 'baidu' | 'kuwo' | null;
   favoritedByMe?: boolean;
   platformIds?: PlatformIds;
@@ -241,6 +244,17 @@ const MusicDetail = () => {
           </div>
         </div>
       </section>
+
+      {song.description ? (
+        <section className="bg-white rounded-[32px] border border-gray-100 p-6 sm:p-8 shadow-sm">
+          <h2 className="text-xl font-serif font-bold text-gray-900 mb-4">歌曲描述</h2>
+          <div className="prose prose-stone max-w-none text-sm text-gray-600">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {song.description}
+            </ReactMarkdown>
+          </div>
+        </section>
+      ) : null}
 
       <section className="bg-white rounded-[32px] border border-gray-100 p-6 sm:p-8 shadow-sm">
         <h2 className="text-xl font-serif font-bold text-gray-900 mb-4">歌词</h2>

--- a/src/pages/MusicDetail.tsx
+++ b/src/pages/MusicDetail.tsx
@@ -4,6 +4,8 @@ import { ArrowLeft, Clock, ExternalLink, Heart, Link2, MessageSquare, Play } fro
 import { clsx } from 'clsx';
 import { format } from 'date-fns';
 import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
 import remarkGfm from 'remark-gfm';
 
 import { apiDelete, apiGet, apiPost } from '../lib/apiClient';
@@ -12,6 +14,7 @@ import { useMusic } from '../context/MusicContext';
 import { useToast } from '../components/Toast';
 import { SongCoverManager } from '../components/SongCoverManager';
 import { SongEditModal } from '../components/SongEditModal';
+import { customSchema, isTrustedIframeDomain } from '../lib/htmlSanitizer';
 import { copyToClipboard, toAbsoluteInternalUrl } from '../lib/copyLink';
 
 type PlatformIds = {
@@ -75,6 +78,58 @@ const formatDate = (value: string | null | undefined) => {
   if (!value) return '刚刚';
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? '刚刚' : format(parsed, 'yyyy-MM-dd');
+};
+
+const SongDescriptionMarkdown = ({ content }: { content: string }) => {
+  const processedContent = content.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, p1, p2) => {
+    const display = p1.trim();
+    const slug = p2 ? p2.trim() : p1.trim();
+    return `[${display}](/wiki/${slug})`;
+  });
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, customSchema]]}
+      components={{
+        iframe: ({ src, width, height, ...props }: React.IframeHTMLAttributes<HTMLIFrameElement>) => {
+          if (!isTrustedIframeDomain(src)) {
+            return null;
+          }
+          return (
+            <iframe
+              src={src}
+              width={width || '100%'}
+              height={height || '400px'}
+              {...props}
+            />
+          );
+        },
+        a: ({ href, children, ...props }) => {
+          if (href && href.startsWith('/wiki/')) {
+            return (
+              <Link to={href} className="text-brand-primary hover:underline" {...props}>
+                {children}
+              </Link>
+            );
+          }
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-primary hover:underline"
+              {...props}
+            >
+              {children}
+            </a>
+          );
+        },
+      }}
+    >
+      {processedContent}
+    </ReactMarkdown>
+  );
 };
 
 const MusicDetail = () => {
@@ -249,9 +304,7 @@ const MusicDetail = () => {
         <section className="bg-white rounded-[32px] border border-gray-100 p-6 sm:p-8 shadow-sm">
           <h2 className="text-xl font-serif font-bold text-gray-900 mb-4">歌曲描述</h2>
           <div className="prose prose-stone max-w-none text-sm text-gray-600">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {song.description}
-            </ReactMarkdown>
+            <SongDescriptionMarkdown content={song.description} />
           </div>
         </section>
       ) : null}


### PR DESCRIPTION
Closes #56

## Summary
- 为 `MusicTrack` 增加可选的 `description` 字段，并补充数据库迁移、接口返回与编辑入口
- 在歌曲编辑弹窗中支持录入描述，并在歌曲详情页按 Markdown 展示创作背景等补充信息
- 沿用站内 Markdown 的链接处理规则，保持百科内链和外链渲染行为一致

## Testing
- npm run db:generate
- npm run lint
- npm test
- npm run build