### PR TITLE
fix: 将百科点赞图标改为点赞手势

### DIFF
--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
 import { customSchema, isTrustedIframeDomain } from '../lib/htmlSanitizer';
-import { Book, Edit3, Plus, ChevronRight, Search, Tag, Clock, User as UserIcon, ArrowLeft, Save, X, Sparkles, History, Calendar, Link2, GitBranch, Network, MapPin, Heart, ThumbsDown, Pin, Image as ImageIcon } from 'lucide-react';
+import { Book, Edit3, Plus, ChevronRight, Search, Tag, Clock, User as UserIcon, ArrowLeft, Save, X, Sparkles, History, Calendar, Link2, GitBranch, Network, MapPin, ThumbsUp, ThumbsDown, Pin, Image as ImageIcon } from 'lucide-react';
 import { useUserPreferences } from '../context/UserPreferencesContext';
 import { ViewModeSelector } from '../components/ViewModeSelector';
 import { VIEW_MODE_CONFIG } from '../lib/viewModes';
@@ -451,7 +451,7 @@ const WikiList = () => {
                       </p>
                       <div className="flex items-center gap-3 text-gray-400 text-xs mt-2">
                         <span className="flex items-center gap-1"><Clock size={10} /> {formatDate(page.updatedAt, 'yyyy-MM-dd')}</span>
-                        <span className="flex items-center gap-1"><Heart size={10} /> {page.likesCount || 0}</span>
+                        <span className="flex items-center gap-1"><ThumbsUp size={10} /> {page.likesCount || 0}</span>
                       </div>
                     </div>
                   </>
@@ -478,7 +478,7 @@ const WikiList = () => {
                     <div className="flex items-center justify-between text-gray-400 text-xs">
                       <div className="flex items-center gap-3">
                         <span className="flex items-center gap-1"><Clock size={12} /> {formatDate(page.updatedAt, 'yyyy-MM-dd')}</span>
-                        <span className="flex items-center gap-1"><Heart size={12} /> {page.likesCount || 0}</span>
+                        <span className="flex items-center gap-1"><ThumbsUp size={12} /> {page.likesCount || 0}</span>
                         <span className="flex items-center gap-1"><ThumbsDown size={12} /> {page.dislikesCount || 0}</span>
                       </div>
                       <ChevronRight size={16} className="group-hover:translate-x-1 transition-transform" />
@@ -738,7 +738,7 @@ const WikiPageView = () => {
                 )}
                 title={page.likedByMe ? '取消点赞' : '点赞'}
               >
-                <Heart size={20} />
+                <ThumbsUp size={20} />
               </button>
               <button
                 onClick={handleToggleDislike}


### PR DESCRIPTION
Refs #41

该 issue 已关闭，但当前 `main` 未见等价修复，这里补提 PR 便于审阅和合并。

## Summary
- 将百科列表和详情页中的点赞图标从心形改为点赞手势
- 保持现有点赞/点踩逻辑和计数不变，只优化交互语义

## Testing
- npm run lint
- npm test
- npm run build