### PR TITLE
fix: 阻止新建百科覆盖同名页面

### DIFF
--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -1744,6 +1744,14 @@ const WikiEditor = () => {
       show("请先填写标题以生成页面标识", { variant: 'error' });
       return;
     }
+
+    if (isNew) {
+      const existingSnap = await getDoc(doc(db, 'wiki', pageSlug));
+      if (existingSnap.exists()) {
+        show('同名页面已存在，请修改标题后重试', { variant: 'error' });
+        return;
+      }
+    }
     
     setSavingMode(status);
 
@@ -1770,12 +1778,7 @@ const WikiEditor = () => {
     try {
       const docRef = doc(db, 'wiki', pageSlug!);
       if (isNew) {
-        const existingSnap = await getDoc(docRef);
-        if (existingSnap.exists()) {
-          await updateDoc(docRef, pageData);
-        } else {
-          await setDoc(docRef, pageData);
-        }
+        await setDoc(docRef, pageData);
       } else {
         await updateDoc(docRef, pageData);
       }


### PR DESCRIPTION
Refs #51

该 issue 已关闭，但当前 `main` 仍存在同名 slug 覆盖风险，这里补提 PR 便于审阅和合并。

## Summary
- 新建百科时先检查目标 slug 是否已存在
- 若同名页面已存在则提示用户修改标题，而不是直接覆盖原页面

## Testing
- npm run lint
- npm test
- npm run build